### PR TITLE
Maintain integer values when resizing labels

### DIFF
--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -313,12 +313,8 @@ def resize(data, shape, data_format='channels_last', labeled_image=False):
 
         # linear interpolation (order 1) for image data, nearest neighbor (order 0) for labels
         # anti_aliasing introduces spurious labels, include only for image data
-        if labeled_image:
-            order = 0
-            anti_aliasing = False
-        else:
-            order = 1
-            anti_aliasing = True
+        order = 0 if labeled_image else 1
+        anti_aliasing = not labeled_image
 
         _resize = lambda d: transform.resize(d, shape, mode='constant', preserve_range=True,
                                              order=order, anti_aliasing=anti_aliasing)

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -298,6 +298,8 @@ def resize(data, shape, data_format='channels_last', labeled_image=False):
         raise ValueError('Shape for resize can only have length of 2, e.g. (x,y).'
                          'Input shape has {} dimensions.'.format(str(len(shape))))
 
+    original_dtype = data.dtype
+
     # cv2 resize is faster but does not support multi-channel data
     # If the data is multi-channel, use skimage.transform.resize
     channel_axis = 0 if data_format == 'channels_first' else -1
@@ -344,7 +346,7 @@ def resize(data, shape, data_format='channels_last', labeled_image=False):
     else:
         resized = _resize(data)
 
-    return resized
+    return resized.astype(original_dtype)
 
 # Workaround for python2 not supporting `with tempfile.TemporaryDirectory() as`
 # These are unnecessary if not supporting python2

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -317,7 +317,7 @@ def resize(data, shape, data_format='channels_last', labeled_image=False):
             order = 0
             anti_aliasing = False
         else:
-            order = 0
+            order = 1
             anti_aliasing = True
 
         _resize = lambda d: transform.resize(d, shape, mode='constant', preserve_range=True,

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -168,7 +168,6 @@ def test_resize():
 
     for out in out_shapes:
         for c in channel_sizes:
-
             # batch, channel first
             in_shape = [c] + base_shape + [4]
             out_shape = tuple([c] + out + [4])

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -192,23 +192,25 @@ def test_resize():
             rs = utils.resize(np.random.rand(*in_shape), out, data_format='channels_last')
             assert out_shape == rs.shape
 
-            # make sure label data is not linearly interpolated and returns only ints
+            # make sure label data is not linearly interpolated and returns only the same ints
 
             # no batch, channel last
             in_shape = base_shape + [c]
             out_shape = tuple(out + [c])
-            in_data = np.random.randint(low=0, high=20, size=in_shape).astype('float32')
+            in_data = np.random.choice(a=[0, 1, 9, 20], size=in_shape, replace=True)
             rs = utils.resize(in_data, out, data_format='channels_last', data_type='y')
             assert out_shape == rs.shape
             assert np.all(rs == np.floor(rs))
+            assert np.all(np.unique(rs) == [0, 1, 9, 20])
 
             # batch, channel first
             in_shape = [c] + base_shape + [4]
             out_shape = tuple([c] + out + [4])
-            in_data = np.random.randint(low=0, high=20, size=in_shape).astype('float32')
+            in_data = np.random.choice(a=[0, 1, 9, 20], size=in_shape, replace=True)
             rs = utils.resize(in_data, out, data_format='channels_first', data_type='y')
             assert out_shape == rs.shape
             assert np.all(rs == np.floor(rs))
+            assert np.all(np.unique(rs) == [0, 1, 9, 20])
 
     # Wrong data size
     with pytest.raises(ValueError):

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -193,6 +193,14 @@ def test_resize():
             rs = utils.resize(np.random.rand(*in_shape), out, data_format='channels_last')
             assert out_shape == rs.shape
 
+            # make sure label data is not linearly interpolated and returns only ints
+            in_shape = base_shape + [c]
+            out_shape = tuple(out + [c])
+            in_data = np.random.randint(low=0, high=20, size=in_shape).astype('float32')
+            rs = utils.resize(in_data, out, data_format='channels_last', data_type='y')
+            assert out_shape == rs.shape
+            assert np.all(rs == np.floor(rs))
+
     # Wrong data size
     with pytest.raises(ValueError):
         im = np.random.rand(20, 20)

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -193,10 +193,20 @@ def test_resize():
             assert out_shape == rs.shape
 
             # make sure label data is not linearly interpolated and returns only ints
+
+            # no batch, channel last
             in_shape = base_shape + [c]
             out_shape = tuple(out + [c])
             in_data = np.random.randint(low=0, high=20, size=in_shape).astype('float32')
             rs = utils.resize(in_data, out, data_format='channels_last', data_type='y')
+            assert out_shape == rs.shape
+            assert np.all(rs == np.floor(rs))
+
+            # batch, channel first
+            in_shape = [c] + base_shape + [4]
+            out_shape = tuple([c] + out + [4])
+            in_data = np.random.randint(low=0, high=20, size=in_shape).astype('float32')
+            rs = utils.resize(in_data, out, data_format='channels_first', data_type='y')
             assert out_shape == rs.shape
             assert np.all(rs == np.floor(rs))
 

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -198,7 +198,7 @@ def test_resize():
             in_shape = base_shape + [c]
             out_shape = tuple(out + [c])
             in_data = np.random.choice(a=[0, 1, 9, 20], size=in_shape, replace=True)
-            rs = utils.resize(in_data, out, data_format='channels_last', data_type='y')
+            rs = utils.resize(in_data, out, data_format='channels_last', labeled_image=True)
             assert out_shape == rs.shape
             assert np.all(rs == np.floor(rs))
             assert np.all(np.unique(rs) == [0, 1, 9, 20])
@@ -207,7 +207,7 @@ def test_resize():
             in_shape = [c] + base_shape + [4]
             out_shape = tuple([c] + out + [4])
             in_data = np.random.choice(a=[0, 1, 9, 20], size=in_shape, replace=True)
-            rs = utils.resize(in_data, out, data_format='channels_first', data_type='y')
+            rs = utils.resize(in_data, out, data_format='channels_first', labeled_image=True)
             assert out_shape == rs.shape
             assert np.all(rs == np.floor(rs))
             assert np.all(np.unique(rs) == [0, 1, 9, 20])


### PR DESCRIPTION
The current implementation of resize uses linear interpolation. This works fine for image data, but for labeled images this will average adjacent labels. I added in a data_type keyword argument to control this behavior, as well as logic to perform nearest-neighbor interpolation for labeled images. 

