### PR TITLE
Remove the reference to fgbg output in deep_watershed.

### DIFF
--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -69,7 +69,6 @@ def deep_watershed(outputs,
     """
     inner_distance_batch = outputs[0][:, ..., 0]
     outer_distance_batch = outputs[1][:, ..., 0]
-    fgbg_batch = outputs[2]
 
     label_images = []
     for batch in range(inner_distance_batch.shape[0]):


### PR DESCRIPTION
The `deep_watershed` post-processing function selects the `fgbg` layer out of the model response, but it is never used. By removing this, the list does not need to contain the fgbg results at all, and post-processing will remain intact.