### PR TITLE
Fix bugs in tile_image and untile_image

### DIFF
--- a/deepcell_toolbox/metrics_test.py
+++ b/deepcell_toolbox/metrics_test.py
@@ -593,7 +593,7 @@ class TestObjectAccuracy():
         assert set(label_dict['catastrophes']['y_pred']) == set(np.unique(y_pred[y_pred > 0]))
 
         # The tests below are more stochastic, and should be run multiple times
-        for _ in range(100):
+        for _ in range(10):
 
             # 3 cells merged together, with forced event links to ensure accurate assignment
             y_true, y_pred = _sample2_3(10, 10, 30, 30, merge=True, similar_size=False)

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -263,7 +263,6 @@ def untile_image(tiles, tiles_info, model_input_shape=(512, 512)):
         t = tile[tile_x_start:tile_x_end, tile_y_start:tile_y_end]
         image[batch, x_start:x_end, y_start:y_end] = t
 
-
     return image
 
 

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -28,12 +28,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import numpy as np
-import cv2
 import contextlib
-import tempfile
 import os
 import shutil
+import tempfile
+
+import numpy as np
+import cv2
 
 from scipy.ndimage import fourier_shift
 from skimage.morphology import ball, disk

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -148,11 +148,13 @@ def tile_image(image, model_input_shape=(512, 512), stride_ratio=0.75):
     tile_size_x = model_input_shape[0]
     tile_size_y = model_input_shape[1]
 
-    stride_x = np.int(stride_ratio * tile_size_x)
-    stride_y = np.int(stride_ratio * tile_size_y)
+    ceil = lambda x: int(np.ceil(x))
 
-    rep_number_x = np.int(np.ceil((image_size_x - tile_size_x) / stride_x + 1))
-    rep_number_y = np.int(np.ceil((image_size_y - tile_size_y) / stride_y + 1))
+    stride_x = ceil(stride_ratio * tile_size_x)
+    stride_y = ceil(stride_ratio * tile_size_y)
+
+    rep_number_x = ceil((image_size_x - tile_size_x) / stride_x + 1)
+    rep_number_y = ceil((image_size_y - tile_size_y) / stride_y + 1)
     new_batch_size = image.shape[0] * rep_number_x * rep_number_y
 
     tiles_shape = (new_batch_size, tile_size_x, tile_size_y, image.shape[3])

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -260,8 +260,9 @@ def untile_image(tiles, tiles_info, model_input_shape=(512, 512)):
         tile_y_start = np.int(tile_y_start)
         tile_y_end = np.int(tile_y_end)
 
-        image[batch, x_start:x_end, y_start:y_end, :] = \
-            tile[tile_x_start:tile_x_end, tile_y_start:tile_y_end, :]
+        t = tile[tile_x_start:tile_x_end, tile_y_start:tile_y_end]
+        image[batch, x_start:x_end, y_start:y_end] = t
+
 
     return image
 

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -246,7 +246,7 @@ def untile_image(tiles, tiles_info, model_input_shape=(512, 512)):
         if y_start != 0:
             y_start += (tile_size_y - stride_y) // 2
             tile_y_start += (tile_size_y - stride_y) // 2
-        if y_end != image_shape[_axis]:
+        if y_end != image_shape[_axis + 1]:
             y_end -= (tile_size_y - stride_y) // 2
             tile_y_end -= (tile_size_y - stride_y) // 2
 

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -135,7 +135,7 @@ def tile_image(image, model_input_shape=(512, 512), stride_ratio=0.75):
     Tile large image into many overlapping tiles of size "model_input_shape".
 
     Args:
-        image (numpy.array): The image to tile.
+        image (numpy.array): The image to tile, must be rank 4.
         model_input_shape (tuple): The input size of the model.
         stride_ratio (float): The ratio of overlap between stride
             and tile shape.
@@ -143,7 +143,14 @@ def tile_image(image, model_input_shape=(512, 512), stride_ratio=0.75):
     Returns:
         tuple(numpy.array, dict): An tuple consisting of an array of tiled
             images and a dictionary of tiling details (for use in un-tiling).
+
+    Raises:
+        ValueError: image is not rank 4.
     """
+    if image.ndim != 4:
+        raise ValueError('Expected image of rank 2, 3 or 4, got {}'.format(
+            image.ndim))
+
     image_size_x, image_size_y = image.shape[1:3]
     tile_size_x = model_input_shape[0]
     tile_size_y = model_input_shape[1]

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -238,17 +238,17 @@ def untile_image(tiles, tiles_info, model_input_shape=(512, 512)):
         tile_y_end = tile_size_y
 
         if x_start != 0:
-            x_start += (tile_size_x - stride_x) / 2
-            tile_x_start += (tile_size_x - stride_x) / 2
+            x_start += (tile_size_x - stride_x) // 2
+            tile_x_start += (tile_size_x - stride_x) // 2
         if x_end != image_shape[_axis]:
-            x_end -= (tile_size_x - stride_x) / 2
-            tile_x_end -= (tile_size_x - stride_x) / 2
+            x_end -= (tile_size_x - stride_x) // 2
+            tile_x_end -= (tile_size_x - stride_x) // 2
         if y_start != 0:
-            y_start += (tile_size_y - stride_y) / 2
-            tile_y_start += (tile_size_y - stride_y) / 2
+            y_start += (tile_size_y - stride_y) // 2
+            tile_y_start += (tile_size_y - stride_y) // 2
         if y_end != image_shape[_axis]:
-            y_end -= (tile_size_y - stride_y) / 2
-            tile_y_end -= (tile_size_y - stride_y) / 2
+            y_end -= (tile_size_y - stride_y) // 2
+            tile_y_end -= (tile_size_y - stride_y) // 2
 
         x_start = np.int(x_start)
         x_end = np.int(x_end)

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -201,15 +201,13 @@ def tile_image(image, model_input_shape=(512, 512), stride_ratio=0.75):
     return tiles, tiles_info
 
 
-def untile_image(tiles, tiles_info,
-                 model_input_shape=(512, 512), dtype=None):
+def untile_image(tiles, tiles_info, model_input_shape=(512, 512)):
     """Untile a set of tiled images back to the original model shape.
 
     Args:
         tiles (numpy.array): The tiled images image to untile.
         tiles_info (dict): Details of how the image was tiled (from tile_image).
         model_input_shape (tuple): The input size of the model.
-        dtype (string): optional dtype for output image, defaults to input image dtype
 
     Returns:
         numpy.array: The untiled image.
@@ -223,14 +221,12 @@ def untile_image(tiles, tiles_info,
     y_ends = tiles_info['y_ends']
     stride_x = tiles_info['stride_x']
     stride_y = tiles_info['stride_y']
-    if dtype is None:
-        dtype = tiles_info['dtype']
 
     tile_size_x = model_input_shape[0]
     tile_size_y = model_input_shape[1]
 
     image_shape = tuple(list(image_shape[0:3]) + [tiles.shape[-1]])
-    image = np.zeros(image_shape, dtype=dtype)
+    image = np.zeros(image_shape, dtype=tiles.dtype)
 
     zipped = zip(tiles, batches, x_starts, x_ends, y_starts, y_ends)
     for tile, batch, x_start, x_end, y_start, y_end in zipped:

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -131,13 +131,13 @@ def test_correct_drift():
 
 def test_tile_image():
     shapes = [
-        (4, 20, 20, 1),
-        (4, 20, 30, 2),
-        (4, 30, 20, 3),
+        (4, 21, 21, 1),
+        (4, 21, 31, 2),
+        (4, 31, 21, 3),
     ]
-    model_input_shapes = [(5, 5), (12, 12)]
+    model_input_shapes = [(3, 3), (5, 5), (7, 7), (12, 12)]
 
-    stride_ratios = [0.5, 0.75, 1]
+    stride_ratios = [0.25, 0.33, 0.5, 0.66, 0.75, 0.8, 1]
 
     dtypes = ['int32', 'float32', 'uint16', 'float16']
 
@@ -155,8 +155,8 @@ def test_tile_image():
 
         x_diff = shape[1] - input_shape[0]
         y_diff = shape[2] - input_shape[1]
-        x_ratio = int(stride_ratio * input_shape[0])
-        y_ratio = int(stride_ratio * input_shape[1])
+        x_ratio = np.ceil(stride_ratio * input_shape[0])
+        y_ratio = np.ceil(stride_ratio * input_shape[1])
 
         expected_batches = shape[0]
         expected_batches *= np.ceil(x_diff / x_ratio + 1)

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -165,6 +165,12 @@ def test_tile_image():
         # pylint: disable=E1136
         assert tiles.shape[0] == expected_batches
 
+    # test bad input shape
+    bad_shape = (21, 21, 1)
+    bad_image = (np.random.random(bad_shape) * 100)
+    with pytest.raises(ValueError):
+        utils.tile_image(bad_image, (5, 5), stride_ratio=0.75)
+
 
 def test_untile_image():
     shapes = [

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -169,8 +169,8 @@ def test_tile_image():
 def test_untile_image():
     shapes = [
         (4, 21, 21, 1),
-        # (4, 21, 31, 1),
-        # (4, 31, 21, 1),
+        (4, 21, 31, 1),
+        (4, 31, 21, 1),
     ]
     model_input_shapes = [(3, 3), (5, 5), (7, 7), (12, 12)]
 

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -167,21 +167,33 @@ def test_tile_image():
 
 
 def test_untile_image():
-    shape = (4, 20, 20, 1)
-    big_image = np.random.random(shape)
-    model_input_shape = (5, 5)
-    stride_ratio = 0.75
-    tiles, tiles_info = utils.tile_image(big_image, model_input_shape,
-                                         stride_ratio=stride_ratio)
+    shapes = [
+        (4, 21, 21, 1),
+        # (4, 21, 31, 1),
+        # (4, 31, 21, 1),
+    ]
+    model_input_shapes = [(3, 3), (5, 5), (7, 7), (12, 12)]
 
-    untiled_image = utils.untile_image(tiles=tiles, tiles_info=tiles_info,
-                                       model_input_shape=model_input_shape, dtype=None)
-    np.testing.assert_equal(untiled_image, big_image)
+    stride_ratios = [0.25, 0.33, 0.5, 0.66, 0.75, 0.8, 1]
 
-    untiled_int = utils.untile_image(tiles=tiles, tiles_info=tiles_info,
-                                     model_input_shape=model_input_shape, dtype='int16')
-    np.testing.assert_equal(untiled_int.dtype, np.dtype('int16'))
-    np.testing.assert_equal(big_image.astype('int16'), untiled_int.astype('int16'))
+    dtypes = ['int32', 'float32', 'uint16', 'float16']
+
+    prod = product(shapes, model_input_shapes, stride_ratios, dtypes)
+
+    for shape, input_shape, stride_ratio, dtype in prod:
+        print(shape, input_shape, stride_ratio, dtype)
+        big_image = (np.random.random(shape) * 100).astype(dtype)
+        tiles, tiles_info = utils.tile_image(
+            big_image, input_shape,
+            stride_ratio=stride_ratio)
+
+        untiled_image = utils.untile_image(
+            tiles=tiles, tiles_info=tiles_info,
+            model_input_shape=input_shape)
+
+        assert untiled_image.dtype == dtype
+        assert untiled_image.shape == (shape)
+        np.testing.assert_equal(untiled_image, big_image)
 
 
 def test_resize():

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -158,6 +158,7 @@ def test_untile_image():
     untiled_int = utils.untile_image(tiles=tiles, tiles_info=tiles_info,
                                      model_input_shape=model_input_shape, dtype='int16')
     np.testing.assert_equal(untiled_int.dtype, np.dtype('int16'))
+    np.testing.assert_equal(big_image.astype('int16'), untiled_int.astype('int16'))
 
 
 def test_resize():

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -197,7 +197,7 @@ def test_untile_image():
             model_input_shape=input_shape)
 
         assert untiled_image.dtype == dtype
-        assert untiled_image.shape == (shape)
+        assert untiled_image.shape == shape
         np.testing.assert_equal(untiled_image, big_image)
 
 

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -187,7 +187,6 @@ def test_untile_image():
     prod = product(shapes, model_input_shapes, stride_ratios, dtypes)
 
     for shape, input_shape, stride_ratio, dtype in prod:
-        print(shape, input_shape, stride_ratio, dtype)
         big_image = (np.random.random(shape) * 100).astype(dtype)
         tiles, tiles_info = utils.tile_image(
             big_image, input_shape,

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -169,8 +169,8 @@ def test_tile_image():
 def test_untile_image():
     shapes = [
         (4, 21, 21, 1),
-        (4, 21, 31, 1),
-        (4, 31, 21, 1),
+        (4, 21, 31, 2),
+        (4, 31, 21, 3),
     ]
     model_input_shapes = [(3, 3), (5, 5), (7, 7), (12, 12)]
 


### PR DESCRIPTION
Fixes #13 
Fixes #12 

This PR removes the `dtype` option for `untile_image` and instead will preserve the `dtype` of the input data `tiles`.

Additionally, this PR adds several tests for `tile_image` and `untile_image` to test different combinations of input shape, model shape, dtype, and stride ratio. In building these tests, a couple of bugs were found in both functions:

* Using `int(np.ceil(x / y))` instead of `int(x / y)` leads to deterministic indices. there were issues with smaller values of `stride_ratio`.
* `untile_image` was checking the x-axis for its terminus point instead of the y-axis, causing problems with some rectangular images.
* Raise `ValueError` if input image to `tile_image` is not 4. (Fixes #12)