### PR TITLE
Replace keras-retinanet with compute_overlap.pyx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Application generated files
+deepcell_toolbox/compute_overlap.cypthon-*
+deepcell_toolbox/compute_overlap.c
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Application generated files
 deepcell_toolbox/compute_overlap.cypthon-*
 deepcell_toolbox/compute_overlap.c
+deepcell_toolbox/compute_overlap_3D.cypthon-*
+deepcell_toolbox/compute_overlap_3D.c
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ cache: pip
 install:
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
+  # install deepcell with setup.py
+  - travis_retry python setup.py build_ext --inplace
 
 script:
   - pytest --cov=deepcell_toolbox --pep8

--- a/deepcell_toolbox/__init__.py
+++ b/deepcell_toolbox/__init__.py
@@ -43,6 +43,8 @@ from deepcell_toolbox.retinanet import retinamask_semantic_postprocess
 from deepcell_toolbox.utils import correct_drift
 from deepcell_toolbox.utils import erode_edges
 
+from deepcell_toolbox.compute_overlap import compute_overlap
+
 # alias for backwards compatibility
 retinanet_to_label_image = retinamask_postprocess
 retinanet_semantic_to_label_image = retinamask_semantic_postprocess

--- a/deepcell_toolbox/__init__.py
+++ b/deepcell_toolbox/__init__.py
@@ -43,7 +43,7 @@ from deepcell_toolbox.retinanet import retinamask_semantic_postprocess
 from deepcell_toolbox.utils import correct_drift
 from deepcell_toolbox.utils import erode_edges
 
-from deepcell_toolbox.compute_overlap import compute_overlap
+from deepcell_toolbox.compute_overlap import compute_overlap  # pylint: disable=E0401
 
 # alias for backwards compatibility
 retinanet_to_label_image = retinamask_postprocess

--- a/deepcell_toolbox/compute_overlap.pyx
+++ b/deepcell_toolbox/compute_overlap.pyx
@@ -1,0 +1,53 @@
+# --------------------------------------------------------
+# Fast R-CNN
+# Copyright (c) 2015 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Written by Sergey Karayev
+# --------------------------------------------------------
+
+cimport cython
+import numpy as np
+cimport numpy as np
+
+
+def compute_overlap(
+    np.ndarray[double, ndim=2] boxes,
+    np.ndarray[double, ndim=2] query_boxes
+):
+    """
+    Args
+        a: (N, 4) ndarray of float
+        b: (K, 4) ndarray of float
+
+    Returns
+        overlaps: (N, K) ndarray of overlap between boxes and query_boxes
+    """
+    cdef unsigned int N = boxes.shape[0]
+    cdef unsigned int K = query_boxes.shape[0]
+    cdef np.ndarray[double, ndim=2] overlaps = np.zeros((N, K), dtype=np.float64)
+    cdef double iw, ih, box_area
+    cdef double ua
+    cdef unsigned int k, n
+    for k in range(K):
+        box_area = (
+            (query_boxes[k, 2] - query_boxes[k, 0] + 1) *
+            (query_boxes[k, 3] - query_boxes[k, 1] + 1)
+        )
+        for n in range(N):
+            iw = (
+                min(boxes[n, 2], query_boxes[k, 2]) -
+                max(boxes[n, 0], query_boxes[k, 0]) + 1
+            )
+            if iw > 0:
+                ih = (
+                    min(boxes[n, 3], query_boxes[k, 3]) -
+                    max(boxes[n, 1], query_boxes[k, 1]) + 1
+                )
+                if ih > 0:
+                    ua = np.float64(
+                        (boxes[n, 2] - boxes[n, 0] + 1) *
+                        (boxes[n, 3] - boxes[n, 1] + 1) +
+                        box_area - iw * ih
+                    )
+                    overlaps[n, k] = iw * ih / ua
+    return overlaps

--- a/deepcell_toolbox/compute_overlap_3D.pyx
+++ b/deepcell_toolbox/compute_overlap_3D.pyx
@@ -1,0 +1,60 @@
+# --------------------------------------------------------
+# Fast R-CNN
+# Copyright (c) 2015 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Written by David Van Valen - adapted from code by Sergey Karayev
+# --------------------------------------------------------
+
+cimport cython
+import numpy as np
+cimport numpy as np
+
+
+def compute_overlap(
+    np.ndarray[double, ndim=2] boxes,
+    np.ndarray[double, ndim=2] query_boxes
+):
+    """
+    Args
+        a: (N, 6) ndarray of float
+        b: (K, 6) ndarray of float
+
+    Returns
+        overlaps: (N, K) ndarray of overlap between boxes and query_boxes
+    """
+    cdef unsigned int N = boxes.shape[0]
+    cdef unsigned int K = query_boxes.shape[0]
+    cdef np.ndarray[double, ndim=2] overlaps = np.zeros((N, K), dtype=np.float64)
+    cdef double iw, ih, id, box_volume
+    cdef double ua
+    cdef unsigned int k, n
+    for k in range(K):
+        box_volume = (
+            (query_boxes[k, 3] - query_boxes[k, 0] + 1) *
+            (query_boxes[k, 4] - query_boxes[k, 1] + 1) *
+            (query_boxes[k, 5] - query_boxes[k, 2] + 1)
+        )
+        for n in range(N):
+            id = (
+                min(boxes[n, 3], query_boxes[k, 3]) -
+                max(boxes[n, 0], query_boxes[k, 0]) + 1
+            )
+            if id > 0:
+                iw = (
+                    min(boxes[n, 4], query_boxes[k, 4]) -
+                    max(boxes[n, 1], query_boxes[k, 1]) + 1
+                )
+                if iw > 0:
+                    ih = (
+                        min(boxes[n, 5], query_boxes[k, 5]) - 
+                        max(boxes[n, 2], query_boxes[k, 2]) + 1
+                    )
+                    if ih > 0:
+                        ua = np.float64(
+                            (boxes[n, 3] - boxes[n, 0] + 1) *
+                            (boxes[n, 4] - boxes[n, 1] + 1) *
+                            (boxes[n, 5] - boxes[n, 2] + 1) +
+                            box_volume - iw * ih * id
+                        )
+                        overlaps[n, k] = iw * ih * id / ua
+    return overlaps

--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -44,8 +44,10 @@ from __future__ import division
 import datetime
 import decimal
 import json
+import logging
 import operator
 import os
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -58,11 +60,9 @@ from scipy.optimize import linear_sum_assignment
 from skimage.measure import regionprops
 from skimage.segmentation import relabel_sequential
 from sklearn.metrics import confusion_matrix
-import logging
-import warnings
 
-from keras_retinanet.utils.compute_overlap import compute_overlap
 from deepcell_toolbox import erode_edges
+from deepcell_toolbox import compute_overlap
 
 
 def stats_pixelbased(y_true, y_pred):

--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -62,7 +62,7 @@ from skimage.segmentation import relabel_sequential
 from sklearn.metrics import confusion_matrix
 
 from deepcell_toolbox import erode_edges
-from deepcell_toolbox.compute_overlap import compute_overlap
+from deepcell_toolbox.compute_overlap import compute_overlap  # pylint: disable=E0401
 
 
 def stats_pixelbased(y_true, y_pred):

--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -62,7 +62,7 @@ from skimage.segmentation import relabel_sequential
 from sklearn.metrics import confusion_matrix
 
 from deepcell_toolbox import erode_edges
-from deepcell_toolbox import compute_overlap
+from deepcell_toolbox.compute_overlap import compute_overlap
 
 
 def stats_pixelbased(y_true, y_pred):

--- a/deepcell_toolbox/retinanet.py
+++ b/deepcell_toolbox/retinanet.py
@@ -35,7 +35,7 @@ from skimage.morphology import remove_small_objects
 from skimage.segmentation import random_walker, relabel_sequential
 from skimage.transform import resize
 
-from deepcell_toolbox import compute_overlap
+from deepcell_toolbox.compute_overlap import compute_overlap
 
 
 def compute_iou(boxes, mask_image):

--- a/deepcell_toolbox/retinanet.py
+++ b/deepcell_toolbox/retinanet.py
@@ -35,7 +35,7 @@ from skimage.morphology import remove_small_objects
 from skimage.segmentation import random_walker, relabel_sequential
 from skimage.transform import resize
 
-from deepcell_toolbox.compute_overlap import compute_overlap
+from deepcell_toolbox.compute_overlap import compute_overlap  # pylint: disable=E0401
 
 
 def compute_iou(boxes, mask_image):

--- a/deepcell_toolbox/retinanet.py
+++ b/deepcell_toolbox/retinanet.py
@@ -35,7 +35,7 @@ from skimage.morphology import remove_small_objects
 from skimage.segmentation import random_walker, relabel_sequential
 from skimage.transform import resize
 
-from keras_retinanet.utils.compute_overlap import compute_overlap
+from deepcell_toolbox import compute_overlap
 
 
 def compute_iou(boxes, mask_image):

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,10 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 
 # Do not run tests in the build folder
-norecursedirs= build, .ipynb_checkpoints
+norecursedirs=
+    build,
+    .ipynb_checkpoints,
+    docs
 
 # PEP-8 The following are ignored:
 # E501 line too long (82 > 79 characters)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ networkx>=2.1
 scikit-learn>=0.19.1,<1
 scikit-image>=0.14.0,<0.17
 scipy>=1.1.0,<2
-keras_retinanet==0.5.1
 numpy>=1.16.4,<2
 opencv-python>=3.4.2.17,<4
+cython>=0.28.0

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from setuptools import setup
-from setuptools import find_packages
+import setuptools
+from distutils.command.build_ext import build_ext as DistUtilsBuildExt
+from setuptools import setup, find_packages
+from setuptools.extension import Extension
 
-VERSION = '0.4.1'
+
+VERSION = '0.5.0'
+
+
+class BuildExtension(setuptools.Command):
+    description = DistUtilsBuildExt.description
+    user_options = DistUtilsBuildExt.user_options
+    boolean_options = DistUtilsBuildExt.boolean_options
+    help_options = DistUtilsBuildExt.help_options
+
+    def __init__(self, *args, **kwargs):
+        from setuptools.command.build_ext import build_ext as SetupToolsBuildExt
+
+        # Bypass __setatrr__ to avoid infinite recursion.
+        self.__dict__['_command'] = SetupToolsBuildExt(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._command, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._command, name, value)
+
+    def initialize_options(self, *args, **kwargs):
+        return self._command.initialize_options(*args, **kwargs)
+
+    def finalize_options(self, *args, **kwargs):
+        ret = self._command.finalize_options(*args, **kwargs)
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+        return ret
+
+    def run(self, *args, **kwargs):
+        return self._command.run(*args, **kwargs)
+
+
+extensions = [
+    Extension(
+        'deepcell_toolbox.compute_overlap',
+        ['deepcell_toolbox/compute_overlap.pyx']
+    ),
+]
 
 setup(name='Deepcell_Toolbox',
       version=VERSION,
@@ -38,12 +80,19 @@ setup(name='Deepcell_Toolbox',
       download_url='https://github.com/vanvalenlab/'
                    'deepcell-toolbox/tarball/{}'.format(VERSION),
       license='LICENSE',
-      install_requires=['keras-retinanet',
+      cmdclass={'build_ext': BuildExtension},
+      install_requires=['cython',
+                        'opencv-python',
+                        'pandas',
+                        'networkx',
                         'numpy',
                         'scipy',
-                        'scikit-image'],
+                        'scikit-image',
+                        'scikit-learn'],
       extras_require={
           'tests': ['pytest',
                     'pytest-pep8',
                     'pytest-cov']},
-      packages=find_packages())
+      packages=find_packages(),
+      ext_modules=extensions,
+      setup_requires=['cython>=0.28', 'numpy>=1.16.4'])


### PR DESCRIPTION
Fixes #38 by removing the dependency on `keras-retinanet` and take the `compute_overlap` function out and using it directly.