### PR TITLE
reformatted multiplex postprocessing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
+  - travis_retry pip install pytest pytest-cov==2.5.1 pytest-pep8 pytest-mock coveralls
   # install deepcell with setup.py
   - travis_retry python setup.py build_ext --inplace
 

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -239,11 +239,12 @@ def deep_watershed_subcellular(model_output, compartment='whole-cell', whole_cel
 
         label_images_nucleus = deep_watershed_mibi(model_output=model_output['nuclear'],
                                                    **nuclear_kwargs)
+
+        label_images = np.concatenate((label_images_cell, label_images_nucleus), axis=-1)
+
     else:
         raise ValueError('Invalid compartment supplied: {}. '
                          'Must be one of {}'.format(compartment, valid_compartments))
-
-        label_images = np.concatenate((label_images_cell, label_images_nucleus), axis=-1)
 
     return label_images
 

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -182,7 +182,6 @@ def deep_watershed_mibi(model_output,
 
         # Remove small objects
         label_image = remove_small_objects(label_image, min_size=small_objects_threshold)
-        print(label_image.shape)
 
         # Relabel the label image
         label_image, _, _ = relabel_sequential(label_image)

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -178,6 +178,7 @@ def deep_watershed_mibi(model_output,
 
         # Remove small objects
         label_image = remove_small_objects(label_image, min_size=small_objects_threshold)
+        print(label_image.shape)
 
         # Relabel the label image
         label_image, _, _ = relabel_sequential(label_image)

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -138,26 +138,24 @@ def deep_watershed_mibi(model_output,
         numpy.array: Uniquely labeled mask.
     """
 
+    cell_model, maxima_model = cell_model.lower(), maxima_model.lower()
+
     valid_model_names = {'inner-distance', 'outer-distance', 'fgbg-fg', 'pixelwise-interior'}
 
-    if cell_model not in valid_model_names:
-        raise ValueError('interior_model must be one of {}, got {}'.format(valid_model_names,
-                                                                           cell_model))
-
-    if maxima_model not in valid_model_names:
-        raise ValueError('maxima_model must be one of {}, got {}'.format(valid_model_names,
-                                                                         maxima_model))
+    for name, model in zip(['cell_model', 'maxima_model'], [cell_model, maxima_model]):
+        if model not in valid_model_names:
+            raise ValueError('{} must be one of {}, got {}'.format(
+                name, valid_model_names, model))
 
     cell_prediction_batch = model_output[cell_model]
     maxima_prediction_batch = model_output[maxima_model]
 
-    if len(cell_prediction_batch.shape) != 4:
-        raise ValueError('Model output must be of length 4. The cell_prediction model '
-                         'provided was of shape {}'.format(cell_prediction_batch.shape))
-
-    if len(maxima_prediction_batch.shape) != 4:
-        raise ValueError('Model output must be of length 4. The maxima_prediction model '
-                         'provided was of shape {}'.format(maxima_prediction_batch.shape))
+    zipped = zip(['cell_prediction', 'maxima_prediction'],
+                 (cell_prediction_batch, maxima_prediction_batch))
+    for name, arr in zipped:
+        if len(arr.shape) != 4:
+            raise ValueError('Model output must be of length 4. The {} model '
+                             'provided was of shape {}'.format(name, arr.shape))
 
     label_images = []
     for batch in range(cell_prediction_batch.shape[0]):

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -66,14 +66,104 @@ def test_deep_watershed_mibi():
     outer_distance = np.random.random(shape) * 100
     fgbg = np.random.randint(0, 1, size=shape)
     pixelwise = np.random.random(shape[:-1] + (3, ))
-    inputs = [inner_distance, outer_distance, fgbg, pixelwise]
+    model_output = {'inner-distance': inner_distance,
+                    'outer-distance': outer_distance,
+                    'fgbg_fg': fgbg,
+                    'pixelwise-interior': pixelwise}
 
     # basic tests
-    watershed_img = deep_watershed.deep_watershed_mibi(inputs)
-    np.testing.assert_equal(watershed_img.shape, shape[:-1])
+    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output)
+    np.testing.assert_equal(watershed_img.shape, shape)
 
     # turn some knobs
-    watershed_img = deep_watershed.deep_watershed_mibi(inputs,
+    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
                                                        small_objects_threshold=1,
                                                        exclude_border=True)
-    np.testing.assert_equal(watershed_img.shape, shape[:-1])
+    np.testing.assert_equal(watershed_img.shape, shape)
+
+
+def test_deep_watershed_subcellular(mocker):
+    # create dict, with each image having a different constant value
+    base_array = np.ones((1, 20, 20, 1))
+
+    whole_cell_list = [base_array * mult for mult in range(1, 5)]
+    whole_cell_dict = {'inner-distance': whole_cell_list[0],
+                       'outer-distance': whole_cell_list[1],
+                       'fgbg-fg': whole_cell_list[2],
+                       'pixelwise-interior': whole_cell_list[3]}
+
+    nuclear_list = [base_array * mult for mult in range(5, 9)]
+    nuclear_dict = {'inner-distance': nuclear_list[0],
+                    'outer-distance': nuclear_list[1],
+                    'fgbg-fg': nuclear_list[2],
+                    'pixelwise-interior': nuclear_list[3]}
+
+    model_output = {'whole-cell': whole_cell_dict, 'nuclear': nuclear_dict}
+
+    # whole cell predictions only
+    whole_cell = deep_watershed.deep_watershed_subcellular(model_output=model_output,
+                                                           compartment='whole-cell')
+    assert whole_cell.shape == (1, 20, 20, 1)
+
+    # nuclear predictions only
+    nuclear = deep_watershed.deep_watershed_subcellular(model_output=model_output,
+                                                        compartment='nuclear')
+    assert nuclear.shape == (1, 20, 20, 1)
+
+    # both whole-cell and nuclear predictions
+    both = deep_watershed.deep_watershed_subcellular(model_output=model_output,
+                                                     compartment='both')
+    assert both.shape == (1, 20, 20, 2)
+
+    # make sure correct arrays are being passed to helper function
+    def mock_deep_watershed_mibi(model_output):
+        pixelwise_interior_vals = model_output['pixelwise-interior']
+        return pixelwise_interior_vals
+
+    mocker.patch('deepcell_toolbox.deep_watershed.deep_watershed_mibi', mock_deep_watershed_mibi)
+
+    # whole cell predictions only
+    whole_cell_mocked = deep_watershed.deep_watershed_subcellular(model_output=model_output,
+                                                                  compartment='whole-cell')
+
+    assert np.array_equal(whole_cell_mocked, whole_cell_dict['pixelwise-interior'])
+
+    # nuclear predictions only
+    whole_cell_mocked = deep_watershed.deep_watershed_subcellular(model_output=model_output,
+                                                                  compartment='nuclear')
+
+    assert np.array_equal(whole_cell_mocked, nuclear_dict['pixelwise-interior'])
+
+    with pytest.raises(ValueError):
+        whole_cell = deep_watershed.deep_watershed_subcellular(model_output=model_output,
+                                                               compartment='invalid')
+
+
+def test_format_output_multiplex():
+
+    # create output list, each with a different constant value across image
+    base_array = np.ones((1, 20, 20, 1))
+
+    whole_cell_list = [base_array * mult for mult in range(1, 8)]
+    whole_cell_list = [whole_cell_list[0],
+                       whole_cell_list[1],
+                       np.concatenate(whole_cell_list[2:4], axis=-1),
+                       np.concatenate(whole_cell_list[4:7], axis=-1)]
+
+    # cre
+    nuclear_list = [img * 2 for img in whole_cell_list]
+
+    combined_list = whole_cell_list + nuclear_list
+
+    output = deep_watershed.format_output_multiplex(combined_list)
+
+    assert set(output.keys()) == {'whole-cell', 'nuclear'}
+
+    assert np.array_equal(output['whole-cell']['inner-distance'], base_array)
+    assert np.array_equal(output['nuclear']['inner-distance'], base_array * 2)
+
+    assert np.array_equal(output['whole-cell']['pixelwise-interior'], base_array * 6)
+    assert np.array_equal(output['nuclear']['pixelwise-interior'], base_array * 12)
+
+    with pytest.raises(ValueError):
+        output = deep_watershed.format_output_multiplex(combined_list[:7])

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -68,7 +68,7 @@ def test_deep_watershed_mibi():
     pixelwise = np.random.random(shape[:-1] + (3, ))
     model_output = {'inner-distance': inner_distance,
                     'outer-distance': outer_distance,
-                    'fgbg_fg': fgbg,
+                    'fgbg-fg': fgbg,
                     'pixelwise-interior': pixelwise}
 
     # basic tests
@@ -79,9 +79,19 @@ def test_deep_watershed_mibi():
     watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
                                                        small_objects_threshold=1,
                                                        exclude_border=True)
+
+    # turn turn
+    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
+                                                       small_objects_threshold=1,
+                                                       exclude_border=True,
+                                                       maxima_model='fgbg-fg',
+                                                       interior_model='outer-distance',
+                                                       min_distance=30,
+                                                       maxima_model_smooth=0)
+
     np.testing.assert_equal(watershed_img.shape, shape)
 
-    for model_under_test in ['cell_model', 'maxima_model']:
+    for model_under_test in ['interior_model', 'maxima_model']:
         with pytest.raises(ValueError):
             bad_model = {model_under_test: 'bad_model_name'}
             watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -72,7 +72,7 @@ def test_deep_watershed_mibi():
                     'pixelwise-interior': pixelwise}
 
     # basic tests
-    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output)
+    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output, **kwargs_dict)
     np.testing.assert_equal(watershed_img.shape, shape)
 
     # turn some knobs
@@ -80,6 +80,15 @@ def test_deep_watershed_mibi():
                                                        small_objects_threshold=1,
                                                        exclude_border=True)
     np.testing.assert_equal(watershed_img.shape, shape)
+
+    for model_under_test in ['cell_model', 'maxima_model']:
+        with pytest.raises(ValueError):
+            bad_model = {model_under_test: 'bad_model_name'}
+            watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
+                                                               **bad_model)
+
+    bad_array = pixelwise[:-1]
+        for
 
 
 def test_deep_watershed_subcellular(mocker):

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -72,7 +72,7 @@ def test_deep_watershed_mibi():
                     'pixelwise-interior': pixelwise}
 
     # basic tests
-    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output, **kwargs_dict)
+    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output)
     np.testing.assert_equal(watershed_img.shape, shape)
 
     # turn some knobs
@@ -87,8 +87,12 @@ def test_deep_watershed_mibi():
             watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
                                                                **bad_model)
 
-    bad_array = pixelwise[:-1]
-        for
+    bad_array = pixelwise[..., 0]
+    for bad_transform in ['inner-distance', 'pixelwise-interior']:
+        bad_model_output = model_output.copy()
+        bad_model_output[bad_transform] = bad_array
+        with pytest.raises(ValueError):
+            watershed_img = deep_watershed.deep_watershed_mibi(model_output=bad_model_output)
 
 
 def test_deep_watershed_subcellular(mocker):


### PR DESCRIPTION
This PR brings in the new functionality vanvalenlab/deepcell-tf#413 for better formatting of model output, and also adapts the existing post-processing functions to handle it. 

- Add format_output_multiplex() to take the list of model outputs, and convert them into a nicely structured dict
- Add deep_watershed_subcellular() to take the formatted model output, and pass either the nuclear predictions, the whole-cell predictions, or both, to deep_watershed_mibi()
- Change deep_watershed_mibi() to expect a dictionary of model outputs, rather than a list
- Pull out additional hard-coded parameters in deep_watershed_mibi and add them as default function arguments to enable them to be changed if desired
- Wrap all of these in a kwargs dict and hide them in high-level functions