### PR TITLE
All processing functions expect a batch dimension

### DIFF
--- a/deepcell_toolbox/processing.py
+++ b/deepcell_toolbox/processing.py
@@ -44,13 +44,17 @@ def normalize(image):
     """Normalize image data by dividing by the maximum pixel value
 
     Args:
-        image: numpy array of image data
+        image (numpy.array): numpy array of image data
 
     Returns:
-        normal_image: normalized image data
+        numpy.array: normalized image data
     """
-    normal_image = (image - image.mean()) / image.std()
-    return normal_image
+    for batch in range(image.shape[0]):
+        for channel in range(image.shape[-1]):
+            img = image[batch, ..., channel]
+            normal_image = (img - img.mean()) / img.std()
+            image[batch, ..., channel] = normal_image
+    return image
 
 
 def histogram_normalization(image, kernel_size=64):

--- a/deepcell_toolbox/processing.py
+++ b/deepcell_toolbox/processing.py
@@ -157,19 +157,20 @@ def mibi(prediction, edge_threshold=.25, interior_threshold=.25):
     return segments.astype('uint16')
 
 
-def watershed(image, min_distance=10, threshold_abs=0.05):
+def watershed(image, min_distance=10, min_size=50, threshold_abs=0.05):
     """Use the watershed method to identify unique cells based
     on their distance transform.
 
     # TODO: labels should be the fgbg output, NOT the union of distances
 
     Args:
-        image: distance transform of image (model output)
-        min_distance: minimum number of pixels separating peaks
-        threshold_abs: minimum intensity of peaks
+        image (numpy.array): distance transform of image (model output)
+        min_distance (int): minimum number of pixels separating peaks
+        min_size (int): removes small objects if smaller than min_size.
+        threshold_abs (float): minimum intensity of peaks
 
     Returns:
-        image mask where each cell is annotated uniquely
+        numpy.array: image mask where each cell is annotated uniquely
     """
     distance = np.argmax(image, axis=-1)
     labels = (distance > 0).astype('int')
@@ -187,7 +188,7 @@ def watershed(image, min_distance=10, threshold_abs=0.05):
     segments = morphology.watershed(-distance, markers, mask=labels)
     results = np.expand_dims(segments, axis=-1)
     results = morphology.remove_small_objects(
-        results, min_size=50, connectivity=1)
+        results, min_size=min_size, connectivity=1)
     return results
 
 

--- a/deepcell_toolbox/processing.py
+++ b/deepcell_toolbox/processing.py
@@ -207,11 +207,8 @@ def pixelwise(prediction, threshold=.8, min_size=50):
     labeled_prediction = np.zeros(prediction.shape[:-1] + (1,))
 
     for batch in range(prediction.shape[0]):
-
         interior = prediction[[batch], ..., 2] > threshold
-
         labeled = ndimage.label(interior)[0]
-
         labeled = morphology.remove_small_objects(
             labeled, min_size=min_size, connectivity=1)
 

--- a/deepcell_toolbox/processing.py
+++ b/deepcell_toolbox/processing.py
@@ -192,7 +192,7 @@ def watershed(image, min_distance=10, min_size=50, threshold_abs=0.05):
     return results
 
 
-def pixelwise(prediction, threshold=.8, min_size=50):
+def pixelwise(prediction, threshold=.8, min_size=50, interior_axis=-2):
     """Post-processing for pixelwise transform predictions.
     Uses the interior predictions to uniquely label every instance.
 
@@ -208,12 +208,12 @@ def pixelwise(prediction, threshold=.8, min_size=50):
     labeled_prediction = np.zeros(prediction.shape[:-1] + (1,))
 
     for batch in range(prediction.shape[0]):
-        interior = prediction[[batch], ..., 2] > threshold
+        interior = prediction[[batch], ..., interior_axis] > threshold
         labeled = ndimage.label(interior)[0]
         labeled = morphology.remove_small_objects(
             labeled, min_size=min_size, connectivity=1)
 
-        labeled_prediction[batch] = labeled
+        labeled_prediction[batch, ..., 0] = labeled
 
     return labeled_prediction
 

--- a/deepcell_toolbox/processing_test.py
+++ b/deepcell_toolbox/processing_test.py
@@ -82,14 +82,14 @@ def test_pixelwise():
     channels = 4
     img = np.random.rand(1, 300, 300, channels)
     pixelwise_img = processing.pixelwise(img)
-    np.testing.assert_equal(pixelwise_img.shape, (300, 300, 1))
+    assert pixelwise_img.shape == img.shape[:-1] + (1,)
 
 
 def test_watershed():
     channels = np.random.randint(4, 8)
-    img = np.random.rand(300, 300, channels)
+    img = np.random.rand(1, 300, 300, channels)
     watershed_img = processing.watershed(img)
-    np.testing.assert_equal(watershed_img.shape, (300, 300, 1))
+    assert watershed_img.shape == img.shape[:-1] + (1,)
 
 
 def test_correct_drift():

--- a/deepcell_toolbox/processing_test.py
+++ b/deepcell_toolbox/processing_test.py
@@ -45,6 +45,8 @@ def _get_image(img_h=300, img_w=300):
 def test_normalize():
     height, width = 300, 300
     img = _get_image(height, width)
+    img = np.expand_dims(img, axis=0)
+    img = np.expand_dims(img, axis=-1)
     normalized_img = processing.normalize(img)
     np.testing.assert_almost_equal(normalized_img.mean(), 0)
     np.testing.assert_almost_equal(normalized_img.var(), 1)


### PR DESCRIPTION
- `normalize` and `pixelwise` expect batch axes (Fixes #21)
- `pixelwise` adds `interior_axis` (defaults to -2) to make it more flexible (Fixes #20)