### PR TITLE
Improvements to erode_edges

### DIFF
--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -28,18 +28,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import contextlib
-import os
-import shutil
-import tempfile
-
 import numpy as np
 import cv2
 import scipy.signal
 
 from scipy.ndimage import fourier_shift
-from skimage.morphology import ball, disk
-from skimage.morphology import binary_erosion
 from skimage.feature import register_translation
 from skimage import transform
 from skimage.segmentation import find_boundaries
@@ -58,25 +51,16 @@ def erode_edges(mask, erosion_width):
     Raises:
         ValueError: mask.ndim is not 2 or 3
     """
+
+    if mask.ndim not in {2, 3}:
+        raise ValueError('erode_edges expects arrays of ndim 2 or 3.'
+                         'Got ndim: {}'.format(mask.ndim))
     if erosion_width:
-        if mask.ndim == 2:
-            new_mask = np.copy(mask)
-            for i in range(erosion_width):
-                boundaries = find_boundaries(new_mask, mode='inner')
-                new_mask[boundaries > 0] = 0
-            return new_mask
-        elif mask.ndim == 3:
-            new_mask = np.zeros(mask.shape)
-            strel = ball(erosion_width)
-            for cell_label in np.unique(mask):
-                if cell_label != 0:
-                    temp_img = mask == cell_label
-                    temp_img = binary_erosion(temp_img, strel)
-                    new_mask = np.where(mask == cell_label, temp_img, new_mask)
-            return np.multiply(new_mask, mask).astype('int')
-        else:
-            raise ValueError('erode_edges expects arrays of ndim 2 or 3.'
-                             'Got ndim: {}'.format(mask.ndim))
+        new_mask = np.copy(mask)
+        for i in range(erosion_width):
+            boundaries = find_boundaries(new_mask, mode='inner')
+            new_mask[boundaries > 0] = 0
+        return new_mask
 
     return mask
 

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -57,7 +57,7 @@ def erode_edges(mask, erosion_width):
                          'Got ndim: {}'.format(mask.ndim))
     if erosion_width:
         new_mask = np.copy(mask)
-        for i in range(erosion_width):
+        for _ in range(erosion_width):
             boundaries = find_boundaries(new_mask, mode='inner')
             new_mask[boundaries > 0] = 0
         return new_mask


### PR DESCRIPTION
This PR has two main changes. The first is to substitute the for loop that erodes each cell individually with the built-in python function find_boundaries. 

The second is to modify the tests for erode_edges_3D to assert that each erosion generates a progressively smaller image. The reason the current tests were failing is because with some frequency, erode_edges_3d would erode the entire image with an erosion_width of 1. This means that the erosion_width 2 image would also be blank, and the assert would fail. 

I modified the test data so that each cell is, on average, larger than it was before, and thus the chances of having all cells completely eroded with an erosion_width of only 1 is unlikely. 

However, it worries me that this issue never cropped up for the 2D data. The radius of the erosion selem is the same for 2D or 3D. Previously the 2D and 3D data were generated identically. So why did this issue of all cells being eroded only ever come up when running the erode_edges_3d function, and not ever with the erode_edges_2d function?