### PR TITLE
tweaked watershed params

### DIFF
--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -36,7 +36,7 @@ from skimage.measure import label
 from skimage.morphology import watershed, remove_small_objects, h_maxima, disk, square, dilation
 from skimage.segmentation import relabel_sequential
 
-from deepcell_toolbox.utils import erode_edges
+from deepcell_toolbox.utils import erode_edges, fill_holes
 
 
 def deep_watershed(outputs,
@@ -106,7 +106,7 @@ def deep_watershed_mibi(model_output,
                         maxima_threshold=0.1,
                         interior_threshold=0.2,
                         small_objects_threshold=0,
-                        fill_holes=True,
+                        fill_holes_threshold=0,
                         interior_model='pixelwise-interior',
                         maxima_model='inner-distance',
                         interior_model_smooth=1,
@@ -129,7 +129,7 @@ def deep_watershed_mibi(model_output,
         maxima_threshold (float): Threshold for the maxima prediction.
         interior_threshold (float): Threshold for the interior prediction.
         small_objects_threshold (int): Removes objects smaller than this size.
-        fill_holes (bool): controls whether holes within segmented objects are filled
+        fill_holes_threshold (int): maximum size for holes within segmented objects to be filled
         interior_model: semantic head to use to predict interior of each object
         maxima_model: semantic head to use to predict maxima of each object
         interior_model_smooth: smoothing factor to apply to interior model predictions
@@ -187,6 +187,10 @@ def deep_watershed_mibi(model_output,
 
         # Remove small objects
         label_image = remove_small_objects(label_image, min_size=small_objects_threshold)
+
+        # fill in holes that lie completely within a segmentation label
+        if fill_holes_threshold > 0:
+            label_image = fill_holes(label_image, size=fill_holes_threshold)
 
         # Relabel the label image
         label_image, _, _ = relabel_sequential(label_image)

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -78,15 +78,13 @@ def test_deep_watershed_mibi():
     # turn some knobs
     watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
                                                        small_objects_threshold=1,
-                                                       exclude_border=True)
+                                                       pixel_expansion=5)
 
     # turn turn
     watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
                                                        small_objects_threshold=1,
-                                                       exclude_border=True,
                                                        maxima_model='fgbg-fg',
                                                        interior_model='outer-distance',
-                                                       min_distance=30,
                                                        maxima_model_smooth=0)
 
     np.testing.assert_equal(watershed_img.shape, shape)

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -85,7 +85,8 @@ def test_deep_watershed_mibi():
                                                        small_objects_threshold=1,
                                                        maxima_model='fgbg-fg',
                                                        interior_model='outer-distance',
-                                                       maxima_model_smooth=0)
+                                                       maxima_model_smooth=0,
+                                                       fill_holes_threshold=4)
 
     np.testing.assert_equal(watershed_img.shape, shape)
 

--- a/deepcell_toolbox/utils_test.py
+++ b/deepcell_toolbox/utils_test.py
@@ -416,3 +416,39 @@ def test_untile_image_3D():
         tiles, tiles_info = utils.tile_image(big_image_test, model_input_shape=(2, 2),
                                              stride_ratio=0)
         untiled_image = utils.untile_image(tiles, tile_info)
+
+
+def test_fill_holes():
+    example_arr = np.zeros((50, 50), dtype='int')
+    example_arr[:5, :5] = 1
+    example_arr[10:20, 10:20] = 2
+    example_arr[30:40, 30:40] = 3
+    example_arr[30:40, 40:50] = 4
+
+    # create hole of size 4
+    example_arr[2:4, 2:4] = 0
+
+    # create hole of size 25
+    example_arr[12:17, 12:17] = 0
+
+    # create hole that borders two cells
+    example_arr[32:34, 38:40] = 0
+
+    filled = utils.fill_holes(label_img=example_arr, size=5)
+
+    # small hole has been filled
+    assert np.sum(filled == 1) == 25
+
+    # large hole has not been filled
+    assert np.sum(filled == 2) == 75
+
+    # hole bordering other cell has not been filled
+    assert np.all(filled[32:34, 38:40] == 0)
+
+    # set size so that large hole is filled
+    filled = utils.fill_holes(label_img=example_arr, size=26)
+    assert np.sum(filled == 2) == 100
+
+    # set size so that small hole is not filled
+    filled = utils.fill_holes(label_img=example_arr, size=3)
+    assert np.sum(filled == 1) == 21


### PR DESCRIPTION
This PR updates the multiplex postprocessing function

- Switches from peak_local_max to h_maxima, which Dave found does a better job at detecting maxima in images

- Adds the option for a pixel expansion to do nuclear-based segmentation


One thing that I wanted to include was a fill_holes option. The remove_small_objects setting will remove small objects from the image. However, for the current multiplex model, these small objects are usually located within another label. So what we'd like to do is remove them, and then change those pixels back to the value of the label they are within. 
However, I couldn't seem to find a function that does this. Do you know of anything that would accomplish this? [skimage.remove_small_holes ](https://scikit-image.org/docs/dev/api/skimage.morphology.html#skimage.morphology.remove_small_holes) returns a binary image, so this won't work. If not I can implement it myself, but figured something like this should exist?