### PR TITLE
Fix dense labels bug in Metrics

### DIFF
--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -188,8 +188,8 @@ class ObjectAccuracy(object):  # pylint: disable=useless-object-inheritance
         self.y_true = y_true
         self.y_pred = y_pred
 
-        self.n_true = len(np.unique(self.y_true)) - 1
-        self.n_pred = len(np.unique(self.y_pred)) - 1
+        self.n_true = len(np.unique(self.y_true[self.y_true > 0]))
+        self.n_pred = len(np.unique(self.y_pred[self.y_pred > 0]))
 
         self.n_obj = self.n_true + self.n_pred
 

--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -188,8 +188,8 @@ class ObjectAccuracy(object):  # pylint: disable=useless-object-inheritance
         self.y_true = y_true
         self.y_pred = y_pred
 
-        self.n_true = len(np.unique(self.y_true[self.y_true > 0]))
-        self.n_pred = len(np.unique(self.y_pred[self.y_pred > 0]))
+        self.n_true = len(np.unique(self.y_true[np.non_zero(self.y_true)]))
+        self.n_pred = len(np.unique(self.y_pred[np.non_zero(self.y_pred)]))
 
         self.n_obj = self.n_true + self.n_pred
 

--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -188,8 +188,8 @@ class ObjectAccuracy(object):  # pylint: disable=useless-object-inheritance
         self.y_true = y_true
         self.y_pred = y_pred
 
-        self.n_true = len(np.unique(self.y_true[np.non_zero(self.y_true)]))
-        self.n_pred = len(np.unique(self.y_pred[np.non_zero(self.y_pred)]))
+        self.n_true = len(np.unique(self.y_true[np.nonzero(self.y_true)]))
+        self.n_pred = len(np.unique(self.y_pred[np.nonzero(self.y_pred)]))
 
         self.n_obj = self.n_true + self.n_pred
 

--- a/deepcell_toolbox/metrics_test.py
+++ b/deepcell_toolbox/metrics_test.py
@@ -250,6 +250,19 @@ def _sample4_loner(w, h, imw, imh, gain):
         return im.astype('int'), pred.astype('int')
 
 
+def _dense_sample():
+    true = np.zeros((10, 10))
+    true[:5, :5] = 1
+    true[:5, 5:] = 2
+    true[5:, :5] = 3
+    true[5:, 5:] = 4
+
+    pred = np.zeros((10, 10))
+    pred[2:, :] = true[2:, :]
+
+    return true.astype('int'), pred.astype('int')
+
+
 class TestMetricFunctions():
 
     def test_pixelstats_output(self):
@@ -493,6 +506,12 @@ class TestObjectAccuracy():
         o._calc_iou()
 
         assert hasattr(o, 'seg_thresh')
+
+        # check that image without any background passes
+        y_true, y_pred = _dense_sample()
+        o = metrics.ObjectAccuracy(y_true=y_true, y_pred=y_pred, test=False)
+
+        o._calc_iou()
 
     def test_calc_iou_3D(self):
         y_true, y_pred = _sample1_3D(10, 10, 30, 30, True, 8)


### PR DESCRIPTION
Metrics currently assumes all images have at least one pixel of background. For images with dense cells and no background, the number of cells is not computed correctly, leading to an indexing error. Closes #53