### PR TITLE
Update testing requirements for python 3.5 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install -r requirements-test.txt
+  - travis_retry pip install -r -U requirements-test.txt
   # install deepcell with setup.py
   - travis_retry python setup.py build_ext --inplace
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install -r -U requirements-test.txt
+  - travis_retry pip install --upgrade -r requirements-test.txt
   # install deepcell with setup.py
   - travis_retry python setup.py build_ext --inplace
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install pytest pytest-cov==2.5.1 pytest-pep8 pytest-mock coveralls
+  - travis_retry pip install -r requirements-test.txt
   # install deepcell with setup.py
   - travis_retry python setup.py build_ext --inplace
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
-pytest>=5.0
-pytest-cov==2.5.1
+pytest
+pytest-cov
 pytest-pep8
 pytest-mock
 coveralls

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov==2.5.1
+pytest-pep8
+pytest-mock
+coveralls

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest
+pytest>=5.0
 pytest-cov==2.5.1
 pytest-pep8
 pytest-mock


### PR DESCRIPTION
- Add a requirements-test.txt for managing test dependencies.
- Use `--upgrade` when installing testing requirements to fix #57 