### PR TITLE
Thresholding of bright image signal

### DIFF
--- a/deepcell_toolbox/processing.py
+++ b/deepcell_toolbox/processing.py
@@ -81,7 +81,7 @@ def histogram_normalization(image, kernel_size=64):
     return image
 
 
-def percentile_threshold(image, percentile=None):
+def percentile_threshold(image, percentile=99.9):
     """Threshold an image to reduce bright spots
 
     Args:
@@ -91,9 +91,6 @@ def percentile_threshold(image, percentile=None):
     Returns:
         np.array: thresholded version of input image
     """
-
-    if percentile is None:
-        percentile = 99.9
 
     processed_image = np.zeros_like(image)
     for img in range(image.shape[0]):
@@ -110,29 +107,6 @@ def percentile_threshold(image, percentile=None):
             processed_image[img, ..., chan] = current_img
 
     return processed_image
-
-
-def multiplex_preprocess(image, **kwargs):
-    """Preprocessing function for multiplex data
-
-    Args:
-        image: array to be processed
-
-    Returns:
-        np.array: processed image array
-    """
-    output = np.copy(image)
-    threshold = kwargs.get('threshold', True)
-    if threshold:
-        percentile = kwargs.get('percentile', 99.9)
-        output = percentile_threshold(image=output, percentile=percentile)
-
-    normalize = kwargs.get('normalize', True)
-    if normalize:
-        kernel_size = kwargs.get('kernel_size', 128)
-        output = histogram_normalization(image=output, kernel_size=kernel_size)
-
-    return output
 
 
 def phase_preprocess(image, kernel_size=64):

--- a/deepcell_toolbox/processing_test.py
+++ b/deepcell_toolbox/processing_test.py
@@ -108,7 +108,7 @@ def test_multiplex_preprocess():
     assert (processed <= 1).all() and (processed >= -1).all()
 
     # maxima have been thresholded to same value
-    assert processed[0, 200, 200, 0] == processed[0, 201, 201, 0]
+    assert np.round(processed[0, 200, 200, 0], 3) == np.round(processed[0, 201, 201, 0], 3)
 
 
 def test_mibi():

--- a/deepcell_toolbox/processing_test.py
+++ b/deepcell_toolbox/processing_test.py
@@ -90,52 +90,6 @@ def test_percentile_threshold():
     assert np.mean(thresholded[..., 1]) < 1
 
 
-def test_multiplex_preprocess():
-    height, width = 300, 300
-    img = _get_image(height, width)
-
-    # make rank 4 (batch, X, y, channel)
-    img = np.expand_dims(img, axis=0)
-    img = np.expand_dims(img, axis=-1)
-
-    # single bright spot
-    img[0, 200, 200, 0] = 5000
-
-    # histogram normalized
-    processed = processing.multiplex_preprocess(img)
-    assert (processed <= 1).all() and (processed >= -1).all()
-
-    # maxima is no longer significantly greater than rest of image
-    new_spot_val = processed[0, 200, 200, 0]
-    processed[0, 200, 200, 0] = 0.5
-    next_max_val = np.max(processed)
-
-    # difference between bright spot and next greatest value is essentially nothing
-    assert np.round(new_spot_val / next_max_val, 1) == 1
-
-    # histogram normalization without thresholding
-    processed_hist = processing.multiplex_preprocess(img, threshold=False)
-    assert (processed_hist <= 1).all() and (processed_hist >= -1).all()
-
-    new_spot_val = processed_hist[0, 200, 200, 0]
-    processed_hist[0, 200, 200, 0] = 0.5
-    next_max_val = np.max(processed_hist)
-    assert np.round(new_spot_val / next_max_val, 1) > 1
-
-    # thresholding without histogram normalization
-    processed_thresh = processing.multiplex_preprocess(img, normalize=False)
-    assert not (processed_thresh <= 1).all()
-
-    new_spot_val = processed_thresh[0, 200, 200, 0]
-    processed_thresh[0, 200, 200, 0] = 0.5
-    next_max_val = np.max(processed_thresh)
-    assert np.round(new_spot_val / next_max_val, 1) == 1
-
-    # no change to image
-    not_processed = processing.multiplex_preprocess(img, normalize=False, threshold=False)
-    assert np.all(not_processed == img)
-
-
 def test_mibi():
     channels = 3
     img = np.random.rand(300, 300, channels)


### PR DESCRIPTION
This PR adds a function, `percentile_threshold`, which thresholds signal in an image above a given percentile. This is useful for very bright signal to bright it back down to the same regime of the rest of the image. 

In addition, because the applications currently only support passing 1 preprocessing function, I created a new preprocessing function, `multiplex_preprocess`, which combines thresholding with histogram normalization