### PR TITLE
Handle blank images in preprocessing

### DIFF
--- a/deepcell_toolbox/processing.py
+++ b/deepcell_toolbox/processing.py
@@ -97,14 +97,17 @@ def percentile_threshold(image, percentile=99.9):
         for chan in range(image.shape[-1]):
             current_img = np.copy(image[img, ..., chan])
             non_zero_vals = current_img[np.nonzero(current_img)]
-            img_max = np.percentile(non_zero_vals, percentile)
 
-            # threshold values down to max
-            threshold_mask = current_img > img_max
-            current_img[threshold_mask] = img_max
+            # only threshold if channel isn't blank
+            if len(non_zero_vals) > 0:
+                img_max = np.percentile(non_zero_vals, percentile)
 
-            # update image
-            processed_image[img, ..., chan] = current_img
+                # threshold values down to max
+                threshold_mask = current_img > img_max
+                current_img[threshold_mask] = img_max
+
+                # update image
+                processed_image[img, ..., chan] = current_img
 
     return processed_image
 

--- a/deepcell_toolbox/processing_test.py
+++ b/deepcell_toolbox/processing_test.py
@@ -70,11 +70,6 @@ def test_histogram_normalization():
     preprocessed_img = processing.phase_preprocess(img)
     assert (preprocessed_img <= 1).all() and (preprocessed_img >= -1).all()
 
-    # test blank image
-    blank_img = np.zeros((1, 40, 40, 1))
-    preprocessed_img = processing.histogram_normalization(blank_img)
-    assert len(np.unique(preprocessed_img)) == 1
-
 
 def test_percentile_threshold():
     image_data = np.random.rand(5, 20, 20, 2)

--- a/deepcell_toolbox/processing_test.py
+++ b/deepcell_toolbox/processing_test.py
@@ -70,6 +70,11 @@ def test_histogram_normalization():
     preprocessed_img = processing.phase_preprocess(img)
     assert (preprocessed_img <= 1).all() and (preprocessed_img >= -1).all()
 
+    # test blank image
+    blank_img = np.zeros((1, 40, 40, 1))
+    preprocessed_img = processing.histogram_normalization(blank_img)
+    assert len(np.unique(preprocessed_img)) == 1
+
 
 def test_percentile_threshold():
     image_data = np.random.rand(5, 20, 20, 2)
@@ -88,6 +93,11 @@ def test_percentile_threshold():
 
     assert np.mean(thresholded[..., 0]) > 10
     assert np.mean(thresholded[..., 1]) < 1
+
+    # blank channels are returned as blank
+    image_data[0, ..., 0] = 0
+    thresholded_blank = processing.percentile_threshold(image=image_data)
+    assert np.all(thresholded_blank[0, ..., 0] == 0)
 
 
 def test_mibi():


### PR DESCRIPTION
The `percentile_threshold` function currently fails if a completely blank image is supplied. This PR closes #66 by adding a check for completely blank images, and skipping thresholding if so. 