### PR TITLE
Add epsilon to normalize computation to prevent zero division.

### DIFF
--- a/deepcell_toolbox/processing.py
+++ b/deepcell_toolbox/processing.py
@@ -40,11 +40,12 @@ from skimage.exposure import rescale_intensity
 from skimage.measure import label
 
 
-def normalize(image):
+def normalize(image, epsilon=1e-07):
     """Normalize image data by dividing by the maximum pixel value
 
     Args:
         image (numpy.array): numpy array of image data
+        epsilon (float): fuzz factor used in numeric expressions.
 
     Returns:
         numpy.array: normalized image data
@@ -52,7 +53,7 @@ def normalize(image):
     for batch in range(image.shape[0]):
         for channel in range(image.shape[-1]):
             img = image[batch, ..., channel]
-            normal_image = (img - img.mean()) / img.std()
+            normal_image = (img - img.mean()) / (img.std() + epsilon)
             image[batch, ..., channel] = normal_image
     return image
 

--- a/deepcell_toolbox/processing_test.py
+++ b/deepcell_toolbox/processing_test.py
@@ -51,6 +51,13 @@ def test_normalize():
     np.testing.assert_almost_equal(normalized_img.mean(), 0)
     np.testing.assert_almost_equal(normalized_img.var(), 1)
 
+    # test single-valued image is non NaN.
+    img = np.ones((height, width))
+    img = np.expand_dims(img, axis=0)
+    img = np.expand_dims(img, axis=-1)
+    normalized_img = processing.normalize(img)
+    np.testing.assert_almost_equal(normalized_img.mean(), 0)
+
 
 def test_histogram_normalization():
     height, width = 300, 300


### PR DESCRIPTION
`processing.normalize` divides the image's mean value by its standard deviation. This PR adds a very small `epsilon` to the standard deviation to prevent any `NaN` issues when the standard deviation is 0.

A default value of `1e-07` is used as that is the default value found in `keras.backend.epsilon()`.

Fixes #71 