### PR TITLE
Set a high score in every batch for in RetinaNet tests

### DIFF
--- a/deepcell_toolbox/retinanet_test.py
+++ b/deepcell_toolbox/retinanet_test.py
@@ -62,7 +62,7 @@ def _retinamask_data(im, semantic=False):
     boxes[..., :] = rp
 
     # scores
-    scores = np.random.random(size=(n_batch, n_det, 1))
+    scores = np.random.random(0, 1, size=(n_batch, n_det, 1))
     # set one score to .999 to force a match
     scores[:, 0, 0] = .999
 

--- a/deepcell_toolbox/retinanet_test.py
+++ b/deepcell_toolbox/retinanet_test.py
@@ -62,7 +62,7 @@ def _retinamask_data(im, semantic=False):
     boxes[..., :] = rp
 
     # scores
-    scores = np.random.random(0, 1, size=(n_batch, n_det, 1))
+    scores = np.random.random(size=(n_batch, n_det, 1))
     # set one score to .999 to force a match
     scores[:, 0, 0] = .999
 

--- a/deepcell_toolbox/retinanet_test.py
+++ b/deepcell_toolbox/retinanet_test.py
@@ -62,8 +62,7 @@ def _retinamask_data(im, semantic=False):
     boxes[..., :] = rp
 
     # scores
-    scores = np.zeros((n_batch, n_det, 1))
-    scores[..., :] = np.random.rand()
+    scores = np.random.random(size=(n_batch, n_det, 1))
 
     # labels
     labels = np.zeros((n_batch, n_det, n_labels))
@@ -89,11 +88,13 @@ def test_retinamask_postprocess():
     im = _sample1(10, 10, 40, 40)
     out = _retinamask_data(im, semantic=False)
 
-    label = retinanet.retinamask_postprocess(out, im.shape)
+    label = retinanet.retinamask_postprocess(
+        out, im.shape, score_threshold=.01)
 
 
 def test_retinamask_semantic_postprocess():
     im = _sample1(10, 10, 40, 40)
     out = _retinamask_data(im, semantic=True)
 
-    label = retinanet.retinamask_semantic_postprocess(out)
+    label = retinanet.retinamask_semantic_postprocess(
+        out, score_threshold=.01)

--- a/deepcell_toolbox/retinanet_test.py
+++ b/deepcell_toolbox/retinanet_test.py
@@ -63,6 +63,8 @@ def _retinamask_data(im, semantic=False):
 
     # scores
     scores = np.random.random(size=(n_batch, n_det, 1))
+    # set one score to .999 to force a match
+    scores[:, 0, 0] = .999
 
     # labels
     labels = np.zeros((n_batch, n_det, n_labels))
@@ -88,13 +90,11 @@ def test_retinamask_postprocess():
     im = _sample1(10, 10, 40, 40)
     out = _retinamask_data(im, semantic=False)
 
-    label = retinanet.retinamask_postprocess(
-        out, im.shape, score_threshold=.01)
+    label = retinanet.retinamask_postprocess(out, im.shape)
 
 
 def test_retinamask_semantic_postprocess():
     im = _sample1(10, 10, 40, 40)
     out = _retinamask_data(im, semantic=True)
 
-    label = retinanet.retinamask_semantic_postprocess(
-        out, score_threshold=.01)
+    label = retinanet.retinamask_semantic_postprocess(out)


### PR DESCRIPTION
The scores are randomly generated in the test data, so it is possible that the scores are all below the `score_threshold`. This PR sets a single score to .999 for each batch in the tests, forcing the score to be above the threshold.