### PR TITLE
Check for divide by zero

### DIFF
--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -599,8 +599,11 @@ class ObjectAccuracy(object):  # pylint: disable=useless-object-inheritance
         Returns:
             pandas.DataFrame: Single row dataframe with error types as columns
         """
+        if self.n_pred == 0:
+            self.precision = 0
+        else:
+            self.precision = self.correct_detections / self.n_pred
 
-        self.precision = self.correct_detections / self.n_pred
         self.recall = self.correct_detections / self.n_true
         self.f1 = hmean([self.recall, self.precision])
 


### PR DESCRIPTION
We currently don't check that there are valid predictions when computing precision, which can lead to divide by zero errors. 