### PR TITLE
Wrap both precision and recall in a try/catch.

### DIFF
--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -599,12 +599,16 @@ class ObjectAccuracy(object):  # pylint: disable=useless-object-inheritance
         Returns:
             pandas.DataFrame: Single row dataframe with error types as columns
         """
-        if self.n_pred == 0:
-            self.precision = 0
-        else:
+        try:
             self.precision = self.correct_detections / self.n_pred
+        except ZeroDivisionError:
+            self.precision = 0
 
-        self.recall = self.correct_detections / self.n_true
+        try:
+            self.recall = self.correct_detections / self.n_true
+        except ZeroDivisionError:
+            self.recall = 0
+
         self.f1 = hmean([self.recall, self.precision])
 
         D = {

--- a/deepcell_toolbox/metrics_test.py
+++ b/deepcell_toolbox/metrics_test.py
@@ -368,6 +368,10 @@ class TestMetricsObject():
         # Check data added to output
         assert before != len(m.output)
 
+        m.calc_object_stats(np.zeros_like(y_true), np.zeros_like(y_pred))
+        assert m.stats['precision'].sum() == 0
+        assert m.stats['recall'].sum() == 0
+
         # Raise input size error
         with testing.assert_raises(ValueError):
             m.calc_object_stats(np.random.rand(10, 10), np.random.rand(10, 10))


### PR DESCRIPTION
Easier to ask for forgiveness than permission.

Try to do the precision and recall division and just catch the `ZeroDivisionError` if it occurs. There should not be a case where `n_true` is 0, but just in case there is, prevent the crash.