### PR TITLE
Import `watershed` from `skimage.segmentation`.

### DIFF
--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -33,8 +33,8 @@ import scipy.ndimage as nd
 
 from skimage.feature import peak_local_max
 from skimage.measure import label
-from skimage.morphology import watershed, remove_small_objects, h_maxima, disk, square, dilation
-from skimage.segmentation import relabel_sequential
+from skimage.morphology import remove_small_objects, h_maxima, disk, square, dilation
+from skimage.segmentation import relabel_sequential, watershed
 
 from deepcell_toolbox.utils import erode_edges, fill_holes
 


### PR DESCRIPTION
`skimage.morphology.watershed` is deprecated and removed in `skimage` v0.19. This PR uses `skimage.segmentation.watershed` instead, which is supported by at least 0.14+.

This resolves an annoying deprecation warning we get every time we use the post-processing function.