### PR TITLE
Combine `deep_watershed` and `deep_watershed_3D` & deprecate `deep_watershed_3D`.

### DIFF
--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -80,8 +80,10 @@ def deep_watershed(outputs,
                                 threshold_abs=detection_threshold,
                                 exclude_border=exclude_border)
 
-        markers = np.zeros(inner_distance.shape)
-        markers[coords[:, 0], coords[:, 1]] = 1
+        # Find peaks and merge equal regions
+        markers = np.zeros_like(inner_distance)
+        slc = tuple([coords[:, i] for i in range(coords.shape[1])])
+        markers[slc] = 1
         markers = label(markers)
         label_image = watershed(-outer_distance,
                                 markers,
@@ -203,65 +205,10 @@ def deep_watershed_mibi(model_output,
     return label_images
 
 
-def deep_watershed_3D(outputs,
-                      min_distance=10,
-                      detection_threshold=0.1,
-                      distance_threshold=0.01,
-                      exclude_border=False,
-                      small_objects_threshold=0):
-    """Postprocessing function for deep watershed models. Thresholds the 3D inner
-    distance prediction to find volumetric cell centroids, which are used to seed a marker
-    based watershed of the (2D or 3D) outer distance prediction.
-
-    Args:
-        outputs (list): DeepWatershed model output. A list of
-            [inner_distance, outer_distance, fgbg].
-
-            - inner_distance: Prediction for the 3D inner distance transform.
-            - outer_distance: Prediction for the 2D or 3D outer distance transform.
-            - fgbg: Prediction for the foregound/background transform.
-
-        min_distance (int): Minimum allowable distance between two cell centroids
-        detection_threshold (float): Threshold for the inner distance.
-        distance_threshold (float): Threshold for the outer distance.
-        exclude_border (bool): Whether to include centroid detections
-            at the border.
-        small_objects_threshold (int): Removes objects smaller than this size.
-
-    Returns:
-        numpy.array: Uniquely labeled mask.
-    """
-    inner_distance_batch = outputs[0][..., 0]
-    outer_distance_batch = outputs[1][..., 0]
-
-    label_images = []
-    for batch in range(inner_distance_batch.shape[0]):
-        inner_distance = inner_distance_batch[batch]
-        outer_distance = outer_distance_batch[batch]
-
-        coords = peak_local_max(inner_distance,
-                                min_distance=min_distance,
-                                threshold_abs=detection_threshold,
-                                exclude_border=exclude_border)
-
-        # Find peaks and merge equal regions
-        markers = np.zeros(inner_distance.shape)
-        markers[coords[:, 0], coords[:, 1], coords[:, 2]] = 1
-        markers = label(markers)
-
-        label_image = watershed(-outer_distance,
-                                markers,
-                                mask=outer_distance > distance_threshold)
-        label_image = erode_edges(label_image, 1)
-
-        # Remove small objects
-        label_image = remove_small_objects(label_image, min_size=small_objects_threshold)
-
-        # Relabel the label image
-        label_image, _, _ = relabel_sequential(label_image)
-
-        label_images.append(label_image)
-
-    label_images = np.stack(label_images, axis=0)
-
-    return label_images
+def deep_watershed_3d(*args, **kwargs):
+    """DEPRECATED. Please use ``deep_watershed`` instead."""
+    text = ('deep_watershed_3d is deprecated and will be removed in a future '
+            'version. Please use '
+            '`deepcell_toolbox.deep_watershed.deep_watershed` instead.')
+    warnings.warn(text, DeprecationWarning)
+    return deep_watershed(*args, **kwargs)

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -205,7 +205,7 @@ def deep_watershed_mibi(model_output,
     return label_images
 
 
-def deep_watershed_3d(*args, **kwargs):
+def deep_watershed_3D(*args, **kwargs):
     """DEPRECATED. Please use ``deep_watershed`` instead."""
     text = ('deep_watershed_3d is deprecated and will be removed in a future '
             'version. Please use '

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -28,6 +28,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import warnings
+
 import numpy as np
 import scipy.ndimage as nd
 


### PR DESCRIPTION
The only difference in these two functions was the dimensionality of the `coords` found in `peak_local_max`. Switching to a comprehension allows us to easily use 2D or 3D data with the same function.

`deep_watershed_3D` is now deprecated (and throws a Deprecation Warning), but is kept for now for backward compatibility.