### PR TITLE
Combine `deep_watershed` and `deep_watershed_mibi`

### DIFF
--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -270,4 +270,4 @@ def deep_watershed_3D(*args, **kwargs):
             'version. Please use '
             '`deepcell_toolbox.deep_watershed.deep_watershed` instead.')
     warnings.warn(text, DeprecationWarning)
-    return deep_watershed(*args, maxima_algorithm='peak_local_max', **kwargs)
+    return deep_watershed(*args, **kwargs)

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -35,7 +35,8 @@ import scipy.ndimage as nd
 
 from skimage.feature import peak_local_max
 from skimage.measure import label
-from skimage.morphology import remove_small_objects, h_maxima, disk, square, dilation, ball
+from skimage.morphology import remove_small_objects, h_maxima
+from skimage.morphology import disk, square, dilation, ball
 from skimage.segmentation import relabel_sequential, watershed
 
 from deepcell_toolbox.utils import erode_edges, fill_holes

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -35,162 +35,153 @@ import scipy.ndimage as nd
 
 from skimage.feature import peak_local_max
 from skimage.measure import label
-from skimage.morphology import remove_small_objects, h_maxima, disk, square, dilation
+from skimage.morphology import remove_small_objects, h_maxima, disk, square, dilation, ball
 from skimage.segmentation import relabel_sequential, watershed
 
 from deepcell_toolbox.utils import erode_edges, fill_holes
 
 
 def deep_watershed(outputs,
-                   min_distance=10,
-                   detection_threshold=0.1,
-                   distance_threshold=0.01,
-                   exclude_border=False,
-                   small_objects_threshold=0):
-    """Postprocessing function for deep watershed models. Thresholds the inner
-    distance prediction to find cell centroids, which are used to seed a marker
-    based watershed of the outer distance prediction.
+                   radius=10,
+                   maxima_threshold=0.1,
+                   interior_threshold=0.01,
+                   maxima_smooth=0,
+                   interior_smooth=1,
+                   maxima_index=0,
+                   interior_index=-1,
+                   label_erosion=0,
+                   small_objects_threshold=0,
+                   fill_holes_threshold=0,
+                   pixel_expansion=None,
+                   maxima_algorithm='h_maxima',
+                   **kwargs):
+    """Uses ``maximas`` and ``interiors`` to perform watershed segmentation.
+    ``maximas`` are used as the watershed seeds for each object and
+    ``interiors`` are used as the watershed mask.
 
     Args:
-        outputs (list): DeepWatershed model output. A list of
-            [inner_distance, outer_distance, fgbg].
-
-            - inner_distance: Prediction for the inner distance transform.
-            - outer_distance: Prediction for the outer distance transform.
-            - fgbg: Prediction for the foregound/background transform.
-
-        min_distance (int): Minimum allowable distance between two cells.
-        detection_threshold (float): Threshold for the inner distance.
-        distance_threshold (float): Threshold for the outer distance.
-        exclude_border (bool): Whether to include centroid detections
-            at the border.
-        small_objects_threshold (int): Removes objects smaller than this size.
-
-    Returns:
-        numpy.array: Uniquely labeled mask.
-    """
-    inner_distance_batch = outputs[0][:, ..., 0]
-    outer_distance_batch = outputs[1][:, ..., 0]
-
-    label_images = []
-    for batch in range(inner_distance_batch.shape[0]):
-        inner_distance = inner_distance_batch[batch]
-        outer_distance = outer_distance_batch[batch]
-
-        coords = peak_local_max(inner_distance,
-                                min_distance=min_distance,
-                                threshold_abs=detection_threshold,
-                                exclude_border=exclude_border)
-
-        # Find peaks and merge equal regions
-        markers = np.zeros_like(inner_distance)
-        slc = tuple(coords[:, i] for i in range(coords.shape[1]))
-        markers[slc] = 1
-        markers = label(markers)
-        label_image = watershed(-outer_distance,
-                                markers,
-                                mask=outer_distance > distance_threshold)
-        label_image = erode_edges(label_image, 1)
-
-        # Remove small objects
-        label_image = remove_small_objects(label_image, min_size=small_objects_threshold)
-
-        # Relabel the label image
-        label_image, _, _ = relabel_sequential(label_image)
-
-        label_images.append(label_image)
-
-    label_images = np.stack(label_images, axis=0)
-
-    return label_images
-
-
-def deep_watershed_mibi(model_output,
-                        radius=10,
-                        maxima_threshold=0.1,
-                        interior_threshold=0.2,
-                        small_objects_threshold=0,
-                        fill_holes_threshold=0,
-                        interior_model='pixelwise-interior',
-                        maxima_model='inner-distance',
-                        interior_model_smooth=1,
-                        maxima_model_smooth=0,
-                        pixel_expansion=None):
-    """Postprocessing function for multiplexed deep watershed models. Thresholds the inner
-    distance prediction to find cell centroids, which are used to seed a marker
-    based watershed of the pixelwise interior prediction.
-
-    Args:
-        model_output (dict): DeepWatershed model output. A dictionary containing key: value pairs
-            with the transform name and the corresponding output. Currently supported keys:
-
-            - inner_distance: Prediction for the inner distance transform.
-            - outer_distance: Prediction for the outer distance transform.
-            - fgbg: Foreground prediction for the foregound/background transform.
-            - pixelwise_interior: Interior prediction for the interior/border/background transform.
-
+        outputs (list): List of [maximas, interiors] model outputs.
+            Use `maxima_index` and `interior_index` if list is longer than 2,
+            or if the outputs are in a different order.
         radius (int): Radius of disk used to search for maxima
         maxima_threshold (float): Threshold for the maxima prediction.
         interior_threshold (float): Threshold for the interior prediction.
+        maxima_smooth (int): smoothing factor to apply to ``maximas``.
+            Use ``0`` for no smoothing.
+        interior_smooth (int): smoothing factor to apply to ``interiors``.
+            Use ``0`` for no smoothing.
+        maxima_index (int): The index of the maxima prediction in ``outputs``.
+        interior_index (int): The index of the interior prediction in
+            ``outputs``.
+        label_erosion (int): Number of pixels to erode segmentation labels.
         small_objects_threshold (int): Removes objects smaller than this size.
-        fill_holes_threshold (int): maximum size for holes within segmented objects to be filled
-        interior_model: semantic head to use to predict interior of each object
-        maxima_model: semantic head to use to predict maxima of each object
-        interior_model_smooth: smoothing factor to apply to interior model predictions
-        maxima_model_smooth: smoothing factor to apply to maxima model predictions
-        pixel_expansion: optional number of pixels to expand segmentation labels
+        fill_holes_threshold (int): Maximum size for holes within segmented
+            objects to be filled.
+        pixel_expansion (int): Number of pixels to expand ``interiors``.
+        maxima_algorithm (str): Algorithm used to locate peaks in ``maximas``.
+            One of ``h_maxima`` (default) or ``peak_local_max``.
+            ``peak_local_max`` is much faster but seems to underperform when
+            given regious of ambiguous maxima.
 
     Returns:
-        numpy.array: Uniquely labeled mask.
+        numpy.array: Integer label mask for instance segmentation.
 
     Raises:
-        ValueError: if interior_model or maxima_model names not in valid_model_names
-        ValueError: if interior_model or maxima_model predictions do not have length 4
+        ValueError: ``outputs`` is not properly formatted.
     """
+    try:
+        maximas = outputs[maxima_index]
+        interiors = outputs[interior_index]
+    except (TypeError, KeyError, IndexError):
+        raise ValueError('`outputs` should be a list of at least two '
+                         'NumPy arryas of equal shape.')
 
-    interior_model, maxima_model = interior_model.lower(), maxima_model.lower()
+    valid_algos = {'h_maxima', 'peak_local_max'}
+    if maxima_algorithm not in valid_algos:
+        raise ValueError('Invalid value for maxima_algorithm: {}. '
+                         'Must be one of {}'.format(
+                             maxima_algorithm, valid_algos))
 
-    valid_model_names = {'inner-distance', 'outer-distance', 'fgbg-fg', 'pixelwise-interior'}
+    # Handle deprecated arguments
+    min_distance = kwargs.pop('min_distance', None)
+    if min_distance is not None:
+        radius = min_distance
+        warnings.warn('`min_distance` is now deprecated in favor of `radius`. '
+                      'The value passed for `radius` will be used.',
+                      DeprecationWarning)
 
-    for name, model in zip(['interior_model', 'maxima_model'], [interior_model, maxima_model]):
-        if model not in valid_model_names:
-            raise ValueError('{} must be one of {}, got {}'.format(
-                name, valid_model_names, model))
+    # distance_threshold vs interior_threshold
+    distance_threshold = kwargs.pop('distance_threshold', None)
+    if distance_threshold is not None:
+        interior_threshold = distance_threshold
+        warnings.warn('`distance_threshold` is now deprecated in favor of '
+                      '`interior_threshold`. The value passed for '
+                      '`distance_threshold` will be used.',
+                      DeprecationWarning)
 
-    interior_predictions = model_output[interior_model]
-    maxima_predictions = model_output[maxima_model]
+    # detection_threshold vs maxima_threshold
+    detection_threshold = kwargs.pop('detection_threshold', None)
+    if detection_threshold is not None:
+        maxima_threshold = detection_threshold
+        warnings.warn('`detection_threshold` is now deprecated in favor of '
+                      '`maxima_threshold`. The value passed for '
+                      '`detection_threshold` will be used.',
+                      DeprecationWarning)
 
-    zipped = zip(['interior_prediction', 'maxima_prediction'],
-                 (interior_predictions, maxima_predictions))
-    for name, arr in zipped:
-        if len(arr.shape) != 4:
-            raise ValueError('Model output must be of length 4. The {} model '
-                             'provided was of shape {}'.format(name, arr.shape))
+    if maximas.shape[:-1] != interiors.shape[:-1]:
+        raise ValueError('All input arrays must have the same shape. '
+                         'Got {} and {}'.format(
+                             maximas.shape, interiors.shape))
+
+    if maximas.ndim not in {4, 5}:
+        raise ValueError('maxima and interior tensors must be rank 4 or 5. '
+                         'Rank 4 is 2D data of shape (batch, x, y, c). '
+                         'Rank 5 is 3D data of shape (batch, frames, x, y, c).')
+
+    selem_fn = ball if maximas.ndim > 4 else disk
+
+    maxima_algorithm = 'peak_local_max' if maximas.ndim > 4 else maxima_algorithm
 
     label_images = []
-    for batch in range(interior_predictions.shape[0]):
-        interior_batch = interior_predictions[batch, ..., 0]
-        interior_batch = nd.gaussian_filter(interior_batch, interior_model_smooth)
+    for maxima, interior in zip(maximas, interiors):
+        # squeeze out the channel dimension if passed
+        maxima = nd.gaussian_filter(maxima[..., 0], maxima_smooth)
+        interior = nd.gaussian_filter(interior[..., 0], interior_smooth)
 
-        if pixel_expansion is not None:
-            interior_batch = dilation(interior_batch, selem=square(pixel_expansion * 2 + 1))
+        if pixel_expansion:
+            selem = square(pixel_expansion * 2 + 1)
+            interior = dilation(interior, selem=selem)
 
-        maxima_batch = maxima_predictions[batch, ..., 0]
-        maxima_batch = nd.gaussian_filter(maxima_batch, maxima_model_smooth)
+        # peak_local_max is much faster but has poorer performance
+        # when dealing with more ambiguous local maxima
+        if maxima_algorithm == 'peak_local_max':
+            coords = peak_local_max(
+                maxima,
+                min_distance=radius,
+                threshold_abs=maxima_threshold,
+                exclude_border=kwargs.get('exclude_border', False))
 
-        markers = h_maxima(image=maxima_batch,
-                           h=maxima_threshold,
-                           selem=disk(radius))
+            markers = np.zeros_like(maxima)
+            slc = tuple(coords[:, i] for i in range(coords.shape[1]))
+            markers[slc] = 1
+        else:
+            # Find peaks and merge equal regions
+            markers = h_maxima(image=maxima,
+                               h=maxima_threshold,
+                               selem=selem_fn(radius))
 
         markers = label(markers)
-
-        label_image = watershed(-interior_batch,
-                                markers,
-                                mask=interior_batch > interior_threshold,
+        label_image = watershed(-1 * interior, markers,
+                                mask=interior > interior_threshold,
                                 watershed_line=0)
 
+        if label_erosion:
+            label_image = erode_edges(label_image, label_erosion)
+
         # Remove small objects
-        label_image = remove_small_objects(label_image, min_size=small_objects_threshold)
+        if small_objects_threshold:
+            label_image = remove_small_objects(label_image,
+                                               min_size=small_objects_threshold)
 
         # fill in holes that lie completely within a segmentation label
         if fill_holes_threshold > 0:
@@ -207,10 +198,75 @@ def deep_watershed_mibi(model_output,
     return label_images
 
 
+def deep_watershed_mibi(model_output,
+                        interior_model='pixelwise-interior',
+                        maxima_model='inner-distance',
+                        **kwargs):
+    """DEPRECATED. Please use ``deep_watershed`` instead.
+
+    Postprocessing function for multiplexed deep watershed models. Thresholds the inner
+    distance prediction to find cell centroids, which are used to seed a marker
+    based watershed of the pixelwise interior prediction.
+
+    Args:
+        model_output (dict): DeepWatershed model output. A dictionary containing key: value pairs
+            with the transform name and the corresponding output. Currently supported keys:
+
+            - inner_distance: Prediction for the inner distance transform.
+            - outer_distance: Prediction for the outer distance transform.
+            - fgbg: Foreground prediction for the foregound/background transform.
+            - pixelwise_interior: Interior prediction for the interior/border/background transform.
+
+        interior_model (str): Name of semantic head used to predict interior
+            of each object.
+        maxima_model (str): Name of semantic head used to predict maxima of
+            each object.
+        kwargs (dict): Keyword arguments for ``deep_watershed``.
+
+    Returns:
+        numpy.array: Uniquely labeled mask.
+
+    Raises:
+        ValueError: if ``interior_model`` or ``maxima_model`` is invalid.
+        ValueError: if ``interior_model`` or ``maxima_model`` predictions
+            do not have length 4
+    """
+    text = ('deep_watershed_mibi is deprecated and will be removed in a '
+            'future version. Please use '
+            '`deepcell_toolbox.deep_watershed.deep_watershed` instead.')
+    warnings.warn(text, DeprecationWarning)
+
+    interior_model = str(interior_model).lower()
+    maxima_model = str(maxima_model).lower()
+
+    valid_model_names = {'inner-distance', 'outer-distance',
+                         'fgbg-fg', 'pixelwise-interior'}
+
+    zipped = zip(['interior_model', 'maxima_model'],
+                 [interior_model, maxima_model])
+
+    for name, model in zipped:
+        if model not in valid_model_names:
+            raise ValueError('{} must be one of {}, got {}'.format(
+                name, valid_model_names, model))
+
+        arr = model_output[model]
+        if len(arr.shape) != 4:
+            raise ValueError('Model output must be of length 4. The {} {} '
+                             'output provided is of shape {}.'.format(
+                                 name, model, arr.shape))
+
+    output = [model_output[maxima_model], model_output[interior_model]]
+
+    label_images = deep_watershed(output, **kwargs)
+
+    return label_images
+
+
 def deep_watershed_3D(*args, **kwargs):
     """DEPRECATED. Please use ``deep_watershed`` instead."""
     text = ('deep_watershed_3d is deprecated and will be removed in a future '
             'version. Please use '
             '`deepcell_toolbox.deep_watershed.deep_watershed` instead.')
     warnings.warn(text, DeprecationWarning)
-    return deep_watershed(*args, **kwargs)
+    return deep_watershed(*args, maxima_algorithm='peak_local_max', **kwargs)

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -84,7 +84,7 @@ def deep_watershed(outputs,
 
         # Find peaks and merge equal regions
         markers = np.zeros_like(inner_distance)
-        slc = tuple([coords[:, i] for i in range(coords.shape[1])])
+        slc = tuple(coords[:, i] for i in range(coords.shape[1]))
         markers[slc] = 1
         markers = label(markers)
         label_image = watershed(-outer_distance,

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -54,6 +54,15 @@ def test_deep_watershed():
                                                     maxima_algorithm=algo)
         np.testing.assert_array_equal(label_img, label_img_2)
 
+        # all the bells and whistels
+        label_img_3 = deep_watershed.deep_watershed(inputs, maxima_algorithm=algo,
+                                                    small_objects_threshold=1,
+                                                    label_erosion=1,
+                                                    pixel_expansion=1,
+                                                    fill_holes_threshold=1)
+
+        np.testing.assert_equal(label_img_3.shape, shape[:-1] + (1,))
+
     # test bad inputs, pairs of maxima and interior shapes
     bad_shapes = [
         ((1, 32, 32, 1), (1, 32, 16, 1)),  # unequal dimensions

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -35,29 +35,57 @@ import pytest
 from deepcell_toolbox import deep_watershed
 
 
-def _get_image(img_h=300, img_w=300):
-    bias = np.random.rand(img_w, img_h) * 64
-    variance = np.random.rand(img_w, img_h) * (255 - 64)
-    img = np.random.rand(img_w, img_h) * variance + bias
-    return img
-
-
 def test_deep_watershed():
     shape = (5, 21, 21, 1)
-    inner_distance = np.random.random(shape) * 100
-    outer_distance = np.random.random(shape) * 100
-    fgbg = np.random.randint(0, 1, size=shape)
-    inputs = [inner_distance, outer_distance, fgbg]
+    maxima = np.random.random(shape) * 100
+    interior = np.random.random(shape) * 100
+    other = np.random.randint(0, 1, size=shape)
+    inputs = [maxima, interior]
 
-    # basic tests
-    watershed_img = deep_watershed.deep_watershed(inputs)
-    np.testing.assert_equal(watershed_img.shape, shape[:-1])
+    # basic tests for both h_maxima and peak_local_max
+    for algo in ('h_maxima', 'peak_local_max'):
+        label_img = deep_watershed.deep_watershed(inputs, maxima_algorithm=algo)
+        np.testing.assert_equal(label_img.shape, shape[:-1] + (1,))
 
-    # turn some knobs
-    watershed_img = deep_watershed.deep_watershed(inputs,
-                                                  small_objects_threshold=1,
-                                                  exclude_border=True)
-    np.testing.assert_equal(watershed_img.shape, shape[:-1])
+        # flip the order and give correct indices, same answer
+        label_img_2 = deep_watershed.deep_watershed([other, maxima, interior],
+                                                    maxima_index=1,
+                                                    interior_index=2,
+                                                    maxima_algorithm=algo)
+        np.testing.assert_array_equal(label_img, label_img_2)
+
+    # test bad inputs, pairs of maxima and interior shapes
+    bad_shapes = [
+        ((1, 32, 32, 1), (1, 32, 16, 1)),  # unequal dimensions
+        ((1, 32, 32, 1), (1, 16, 32, 1)),  # unequal dimensions
+        ((32, 32, 1), (32, 32, 1)),  # no batch dimension
+        ((1, 32, 32), (1, 32, 32)),  # no channel dimension
+        ((1, 5, 10, 32, 32, 1), (1, 5, 10, 32, 32, 1)),  # too many dims
+    ]
+    for bad_maxima_shape, bad_interior_shape in bad_shapes:
+        bad_inputs = [np.random.random(bad_maxima_shape),
+                      np.random.random(bad_interior_shape)]
+        with pytest.raises(ValueError):
+            deep_watershed.deep_watershed(bad_inputs)
+
+    # test bad values of maxima_algorithm.
+    with pytest.raises(ValueError):
+        deep_watershed.deep_watershed(inputs, maxima_algorithm='invalid')
+
+    # test deprecated values still work
+    # each pair is the deprecated name, then the new name.
+    old_new_pairs = [
+        ('min_distance', 'radius', np.random.randint(10)),
+        ('distance_threshold', 'interior_threshold', np.random.randint(1, 100) / 100),
+        ('detection_threshold', 'maxima_threshold', np.random.randint(1, 100) / 100),
+    ]
+    for deprecated_arg, new_arg, value in old_new_pairs:
+        dep_kwargs = {deprecated_arg: value}
+        new_kwargs = {new_arg: value}
+
+        dep_img = deep_watershed.deep_watershed(inputs, **dep_kwargs)
+        new_img = deep_watershed.deep_watershed(inputs, **new_kwargs)
+        np.testing.assert_array_equal(dep_img, new_img)
 
 
 def test_deep_watershed_mibi():
@@ -106,17 +134,17 @@ def test_deep_watershed_mibi():
 
 def test_deep_watershed_3D():
     shape = (5, 10, 21, 21, 1)
-    inner_distance = np.random.random(shape) * 100
-    outer_distance = np.random.random(shape) * 100
-    fgbg = np.random.randint(0, 1, size=shape)
-    inputs = [inner_distance, outer_distance, fgbg]
+    maxima = np.random.random(shape) * 100
+    interior = np.random.random(shape) * 100
+    other = np.random.randint(0, 1, size=shape)
+    inputs = [maxima, interior]
 
     # basic tests
-    watershed_img = deep_watershed.deep_watershed_3D(inputs)
-    np.testing.assert_equal(watershed_img.shape, shape[:-1])
+    label_img = deep_watershed.deep_watershed(inputs)
+    np.testing.assert_equal(label_img.shape, shape[:-1] + (1,))
 
-    # turn some knobs
-    watershed_img = deep_watershed.deep_watershed_3D(inputs,
-                                                     small_objects_threshold=1,
-                                                     exclude_border=True)
-    np.testing.assert_equal(watershed_img.shape, shape[:-1])
+    # flip the order and give correct indices, same answer
+    label_img_2 = deep_watershed.deep_watershed([other, maxima, interior],
+                                                maxima_index=1,
+                                                interior_index=2)
+    np.testing.assert_array_equal(label_img, label_img_2)

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -54,7 +54,7 @@ def test_deep_watershed():
                                                     maxima_algorithm=algo)
         np.testing.assert_array_equal(label_img, label_img_2)
 
-        # all the bells and whistels
+        # all the bells and whistles
         label_img_3 = deep_watershed.deep_watershed(inputs, maxima_algorithm=algo,
                                                     small_objects_threshold=1,
                                                     label_erosion=1,
@@ -80,6 +80,15 @@ def test_deep_watershed():
     # test bad values of maxima_algorithm.
     with pytest.raises(ValueError):
         deep_watershed.deep_watershed(inputs, maxima_algorithm='invalid')
+
+    # pass weird data types
+    bad_inputs = [
+        {'interior-distance': maxima, 'outer-distance': interior},
+        None,
+    ]
+    for bad_input in bad_inputs:
+        with pytest.raises(ValueError):
+            _ = deep_watershed.deep_watershed(bad_input)
 
     # test deprecated values still work
     # each pair is the deprecated name, then the new name.
@@ -148,12 +157,28 @@ def test_deep_watershed_3D():
     other = np.random.randint(0, 1, size=shape)
     inputs = [maxima, interior]
 
-    # basic tests
-    label_img = deep_watershed.deep_watershed(inputs)
-    np.testing.assert_equal(label_img.shape, shape[:-1] + (1,))
+    # basic tests for both h_maxima and peak_local_max
+    for algo in ('h_maxima', 'peak_local_max'):
+        label_img = deep_watershed.deep_watershed(inputs, maxima_algorithm=algo)
+        np.testing.assert_equal(label_img.shape, shape[:-1] + (1,))
 
-    # flip the order and give correct indices, same answer
-    label_img_2 = deep_watershed.deep_watershed([other, maxima, interior],
-                                                maxima_index=1,
-                                                interior_index=2)
-    np.testing.assert_array_equal(label_img, label_img_2)
+        # flip the order and give correct indices, same answer
+        label_img_2 = deep_watershed.deep_watershed([other, maxima, interior],
+                                                    maxima_index=1,
+                                                    interior_index=2,
+                                                    maxima_algorithm=algo)
+        np.testing.assert_array_equal(label_img, label_img_2)
+
+        # all the bells and whistles
+        label_img_3 = deep_watershed.deep_watershed(inputs, maxima_algorithm=algo,
+                                                    small_objects_threshold=1,
+                                                    label_erosion=1,
+                                                    pixel_expansion=1,
+                                                    fill_holes_threshold=1)
+
+        np.testing.assert_equal(label_img_3.shape, shape[:-1] + (1,))
+
+        # test deprecated `deep_watershed_3D` function
+        label_img_3d = deep_watershed.deep_watershed_3D(
+            inputs, maxima_algorithm=algo)
+        np.testing.assert_array_equal(label_img, label_img_3d)


### PR DESCRIPTION
This PR combines `deep_watershed` and `deep_watershed_mibi` into a single function, `deep_watershed`.

The following arguments have been deprecated in favor of their `deep_watershed_mibi` alternatives (due to readability/understandability):

- `min_distance` deprecated in favor of `radius`
- `distance_threshold` deprecated in favor of `interior_threshold`
- `detection_threshold` deprecated in favor of `maxima_threshold`

Additionally, new arguments have been moved over from `deep_watershed_mibi`:

- `maxima_smooth` and `interior_smooth` to smooth the inputs with a gaussian filter.
- `fill_holes_threshold` to fill holes smaller than this many pixels
- `pixel_expansion` to expand the `interior` array
- `maxima_algorithm` to switch from `h_maxima` peak finder to `peak_local_max`. By default, `deep_watershed` now uses `h_maxima` to find the peaks in an image. However, to use the previous algorithm, the user can pass `peak_local_max` instead. This is found to be less accurate but faster, and may be suitable for unambiguous peaks.

The input to the function is still a list of two numpy arrays, though more can be passed as long as the indices of the maxima and interior arrays are passed with `maxima_index` and `interior_index`.

Finally, `label_erosion` was added as a parameter to enable eroding labels (as performed by `deep_watershed` by default).

---

This PR leaves `deep_watershed_3D` and `deep_watershed_mibi` as importable functions, but they will just use `deep_watershed` internally. These will be removed in a future version, along with the deprecated arguments.

---

Fixes #51 