### PR TITLE
Cache the entire Python environment to speed up build times.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,16 +23,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Cache pip
+    - name: Cache Python
       uses: actions/cache@v2
       with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+          ${{ env.pythonLocation }}-
 
     - name: Install Dependencies
       env:


### PR DESCRIPTION
## What
* Cache the entire Python environment in the testing GitHub Action workflow.

## Why
* [Drastically speed up build times](https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d).
