### PR TITLE
Set Recall, Precision, and SEG to all have same scale.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
         MPLBACKEND: TkAgg
       run: |
         python -m pip install --upgrade pip
-        pip install .[tests] coveralls
+        pip install .[tests] coveralls<3.3.0
         python setup.py build_ext --inplace
   
     - name: PyTest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
         MPLBACKEND: TkAgg
       run: |
         python -m pip install --upgrade pip
-        pip install .[tests] coveralls<3.3.0
+        pip install .[tests] "coveralls<3.3.0"
         python setup.py build_ext --inplace
   
     - name: PyTest

--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -1146,8 +1146,8 @@ class Metrics(object):
             'n_true': n_true,
             'n_pred': n_pred,
             'recall': _round(recall),
-            'precision': _round(precision * 100),
-            'seg': _round(seg * 100),
+            'precision': _round(precision),
+            'seg': _round(seg),
             'jaccard': _round(jaccard),
             'total_errors': 0,
         }

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,10 +9,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 
 # Do not run tests in the build folder
-norecursedirs=
-    build,
-    .ipynb_checkpoints,
-    docs
+norecursedirs= build .ipynb_checkpoints docs
 
 # PEP-8 The following are ignored:
 # E501 line too long (82 > 79 characters)


### PR DESCRIPTION
Precision and SEG were being multiplied by 100 while Recall was not. This removes the 100x casting to make all metrics be in the same range [0, 1].

Additionally, fixes the `norecursedirs` value in `pytest.ini` to be space-delimited instead of comma-delimited.

Finally, pins `coveralls<3.3.0` to prevent a breaking change in the latest release.

Fixes #117 