### PR TITLE
Pin python-version to 3.8 for PyPI deployment.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
 
     - name: Build a source distribution
       run: python setup.py sdist


### PR DESCRIPTION
numpy restriction for the toolbox requires Python < 3.10