### PR TITLE
Add Python3.10 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: PyTest
       run: |
-        pytest --cov deepcell_toolbox --pep8
+        pytest --cov deepcell_toolbox
 
     - name: Coveralls
       if: env.COVERALLS_REPO_TOKEN != null

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,15 +10,3 @@ filterwarnings =
 
 # Do not run tests in the build folder
 norecursedirs= build .ipynb_checkpoints docs
-
-# PEP-8 The following are ignored:
-# E501 line too long (82 > 79 characters)
-# E731 do not assign a lambda expression, use a def
-# W503 line break occurred before a binary operator
-
-pep8ignore=* E402 \
-           * E731 \
-           * W503
-
-# Enable line length testing with maximum line length of 99
-pep8maxlinelength = 99

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(name=about['__title__'],
           'scikit-learn',
           'tqdm'],
       extras_require={
-          'tests': ['pytest<6',
+          'tests': ['pytest',
                     'pytest-pep8',
                     'pytest-cov',
                     'pytest-mock']},
@@ -115,10 +115,11 @@ setup(name=about['__title__'],
       packages=find_packages(),
       ext_modules=extensions,
       setup_requires=['cython>=0.28', 'numpy>=1.16.6'],
-      python_requires='>=3.7, <3.10',
+      python_requires='>=3.7, <3.11',
       classifiers=[
           'Programming Language :: Python',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.9'])
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10'])

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ setup(name=about['__title__'],
           'tqdm'],
       extras_require={
           'tests': ['pytest',
-                    'pytest-pep8',
                     'pytest-cov',
                     'pytest-mock']},
       long_description=readme,


### PR DESCRIPTION
Adds support for Python 3.10. No changes to the underlying library but some dependency updates were required, the main ones being:
 - removing the upper-bound on `pytest`, and
 - Dropping the `pytest-pep8` extension, which [hasn't been actively maintained in over 8 years](https://pypi.org/project/pytest-pep8/#history)

We can of course re-add code linting using different tooling - I'm happy to do so but would prefer to leave it for a follow-up PR.