### PR TITLE
MAINT: update deprecated code from dependencies and remove warnings filters

### DIFF
--- a/deepcell_toolbox/__version__.py
+++ b/deepcell_toolbox/__version__.py
@@ -28,7 +28,7 @@ __title__ = 'DeepCell_Toolbox'
 __description__ = 'The pre- and post-processing functions module for ' \
     'deepcell-tf.'
 __url__ = 'https://github.com/vanvalenlab/deepcell-toolbox'
-__version__ = '0.11.2'
+__version__ = '0.12.0'
 __author__ = 'Van Valen Lab'
 __author_email__ = 'vanvalenlab@gmail.com'
 __license__ = 'LICENSE'

--- a/deepcell_toolbox/deep_watershed.py
+++ b/deepcell_toolbox/deep_watershed.py
@@ -159,7 +159,7 @@ def deep_watershed(outputs,
 
         if pixel_expansion:
             fn = cube if input_is_3d else square
-            interior = dilation(interior, selem=fn(pixel_expansion * 2 + 1))
+            interior = dilation(interior, footprint=fn(pixel_expansion * 2 + 1))
 
         # peak_local_max is much faster but has poorer performance
         # when dealing with more ambiguous local maxima
@@ -178,7 +178,7 @@ def deep_watershed(outputs,
             fn = ball if input_is_3d else disk
             markers = h_maxima(image=maxima,
                                h=maxima_threshold,
-                               selem=fn(radius))
+                               footprint=fn(radius))
 
         markers = label(markers)
         label_image = watershed(-1 * interior, markers,

--- a/deepcell_toolbox/deep_watershed_test.py
+++ b/deepcell_toolbox/deep_watershed_test.py
@@ -101,7 +101,8 @@ def test_deep_watershed():
         dep_kwargs = {deprecated_arg: value}
         new_kwargs = {new_arg: value}
 
-        dep_img = deep_watershed.deep_watershed(inputs, **dep_kwargs)
+        with pytest.deprecated_call():
+            dep_img = deep_watershed.deep_watershed(inputs, **dep_kwargs)
         new_img = deep_watershed.deep_watershed(inputs, **new_kwargs)
         np.testing.assert_array_equal(dep_img, new_img)
 
@@ -118,36 +119,43 @@ def test_deep_watershed_mibi():
                     'pixelwise-interior': pixelwise}
 
     # basic tests
-    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output)
+    with pytest.deprecated_call():
+        watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output)
     np.testing.assert_equal(watershed_img.shape, shape)
 
     # turn some knobs
-    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
-                                                       small_objects_threshold=1,
-                                                       pixel_expansion=5)
+    with pytest.deprecated_call():
+        watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
+                                                           small_objects_threshold=1,
+                                                           pixel_expansion=5)
 
     # turn turn
-    watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
-                                                       small_objects_threshold=1,
-                                                       maxima_model='fgbg-fg',
-                                                       interior_model='outer-distance',
-                                                       maxima_model_smooth=0,
-                                                       fill_holes_threshold=4)
+    with pytest.deprecated_call():
+        watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
+                                                           small_objects_threshold=1,
+                                                           maxima_model='fgbg-fg',
+                                                           interior_model='outer-distance',
+                                                           maxima_model_smooth=0,
+                                                           fill_holes_threshold=4)
 
     np.testing.assert_equal(watershed_img.shape, shape)
 
     for model_under_test in ['interior_model', 'maxima_model']:
         with pytest.raises(ValueError):
             bad_model = {model_under_test: 'bad_model_name'}
-            watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
-                                                               **bad_model)
+            with pytest.deprecated_call():
+                watershed_img = deep_watershed.deep_watershed_mibi(model_output=model_output,
+                                                                   **bad_model)
 
     bad_array = pixelwise[..., 0]
     for bad_transform in ['inner-distance', 'pixelwise-interior']:
         bad_model_output = model_output.copy()
         bad_model_output[bad_transform] = bad_array
         with pytest.raises(ValueError):
-            watershed_img = deep_watershed.deep_watershed_mibi(model_output=bad_model_output)
+            with pytest.deprecated_call():
+                watershed_img = deep_watershed.deep_watershed_mibi(
+                    model_output=bad_model_output
+                )
 
 
 def test_deep_watershed_3D():
@@ -170,15 +178,17 @@ def test_deep_watershed_3D():
         np.testing.assert_array_equal(label_img, label_img_2)
 
         # all the bells and whistles
-        label_img_3 = deep_watershed.deep_watershed(inputs, maxima_algorithm=algo,
-                                                    small_objects_threshold=1,
-                                                    label_erosion=1,
-                                                    pixel_expansion=1,
-                                                    fill_holes_threshold=1)
+        with pytest.warns(UserWarning, match="`fill_holes` is not supported for 3D data"):
+            label_img_3 = deep_watershed.deep_watershed(inputs, maxima_algorithm=algo,
+                                                        small_objects_threshold=1,
+                                                        label_erosion=1,
+                                                        pixel_expansion=1,
+                                                        fill_holes_threshold=1)
 
         np.testing.assert_equal(label_img_3.shape, shape[:-1] + (1,))
 
         # test deprecated `deep_watershed_3D` function
-        label_img_3d = deep_watershed.deep_watershed_3D(
-            inputs, maxima_algorithm=algo)
+        with pytest.deprecated_call():
+            label_img_3d = deep_watershed.deep_watershed_3D(
+                inputs, maxima_algorithm=algo)
         np.testing.assert_array_equal(label_img, label_img_3d)

--- a/deepcell_toolbox/metrics.py
+++ b/deepcell_toolbox/metrics.py
@@ -942,7 +942,7 @@ class Metrics(object):
         L = []
 
         # Write out average statistics
-        for k, v in df.mean().iteritems():
+        for k, v in df.mean().items():
             L.append(dict(
                 name=k,
                 value=v,
@@ -952,7 +952,7 @@ class Metrics(object):
 
         # Save individual stats to list
         for i, row in df.iterrows():
-            for k, v in row.iteritems():
+            for k, v in row.items():
                 L.append(dict(
                     name=k,
                     value=v,

--- a/deepcell_toolbox/metrics_test.py
+++ b/deepcell_toolbox/metrics_test.py
@@ -389,9 +389,8 @@ class TestObjectMetrics():
         print(o)
 
         # Test using float dtype warns but still works
-        o = metrics.ObjectMetrics(
-            y_true.astype('float'),
-            y_true.astype('float'))
+        with pytest.warns(UserWarning, match="Casting.*from float64 to int"):
+            o = metrics.ObjectMetrics(y_true.astype('float'), y_true.astype('float'))
 
         # test errors thrown for improper ndim inputs
         y_true = np.zeros(shape=(10))  # too few dimensions
@@ -606,8 +605,9 @@ class TestMetrics():
         # each row of metrics corresponds to a batch
         assert len(object_metrics) == len(y_true)
 
-        object_metrics = m.calc_object_stats(
-            np.zeros_like(y_true), np.zeros_like(y_pred))
+        with pytest.warns(UserWarning, match=".*prediction and truth arrays are empty"):
+            object_metrics = m.calc_object_stats(
+                np.zeros_like(y_true), np.zeros_like(y_pred))
 
         # test accuracy of metrics with blank predictions
         assert object_metrics['precision'].sum() == 0
@@ -642,8 +642,9 @@ class TestMetrics():
         assert len(object_metrics) == len(y_true)
 
         # test accuracy of metrics with blank predictions
-        object_metrics = m.calc_object_stats(
-            np.zeros_like(y_true), np.zeros_like(y_pred))
+        with pytest.warns(UserWarning, match=".*prediction and truth arrays are empty"):
+            object_metrics = m.calc_object_stats(
+                np.zeros_like(y_true), np.zeros_like(y_pred))
 
         assert object_metrics['precision'].sum() == 0
         assert object_metrics['recall'].sum() == 0

--- a/deepcell_toolbox/processing.py
+++ b/deepcell_toolbox/processing.py
@@ -221,13 +221,16 @@ def watershed(image, min_distance=10, min_size=50, threshold_abs=0.05):
     distance = np.argmax(image, axis=-1)
     labels = (distance > 0).astype('int')
 
-    local_maxi = peak_local_max(
+    local_maxi_coords = peak_local_max(
         image[..., -1],
         min_distance=min_distance,
         threshold_abs=threshold_abs,
-        indices=False,
         labels=labels,
         exclude_border=False)
+
+    # Construct mask from local_maxi coords
+    local_maxi = np.zeros_like(image[..., -1], dtype=bool)
+    local_maxi[tuple(local_maxi_coords.T)] = True
 
     # markers = label(local_maxi)
     markers = ndimage.label(local_maxi)[0]

--- a/deepcell_toolbox/utils.py
+++ b/deepcell_toolbox/utils.py
@@ -360,7 +360,7 @@ def untile_image(tiles, tiles_info, power=2, **kwargs):
 
     image_shape = [image_shape[0], image_shape[1], image_shape[2], tiles.shape[-1]]
     window_size = (tile_size_x, tile_size_y)
-    image = np.zeros(image_shape, dtype=np.float)
+    image = np.zeros(image_shape, dtype=float)
 
     window_cache = {}
     for x, y in zip(overlaps_x, overlaps_y):
@@ -622,7 +622,7 @@ def untile_image_3D(tiles, tiles_info, power=3, force=False, **kwargs):
 
     image_shape = tuple(list(image_shape[:4]) + [tiles.shape[-1]])
     window_size = (tile_size_z, tile_size_x, tile_size_y)
-    image = np.zeros(image_shape, dtype=np.float)
+    image = np.zeros(image_shape, dtype=float)
 
     tile_data_zip = zip(tiles, batches, x_starts, x_ends, y_starts,
                         y_ends, z_starts, z_ends, overlaps_x, overlaps_y, overlaps_z)

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,10 +3,5 @@
 addopts=-v
         --durations=20
 
-# Ignore Deprecation Warnings
-filterwarnings =
-    ignore::DeprecationWarning
-    ignore::PendingDeprecationWarning
-
 # Do not run tests in the build folder
 norecursedirs= build .ipynb_checkpoints docs


### PR DESCRIPTION
The current pytest configuration is [suppressing all deprecation warnings](https://github.com/vanvalenlab/deepcell-toolbox/blob/fd398ebf1b21e313870aed745413503dacfb29f2/pytest.ini#L6-L9), which includes warnings from dependency libraries. This makes it much more likely for code to fall out-of-date, as can be seen in [the recent failing CI jobs](https://github.com/vanvalenlab/deepcell-toolbox/actions/runs/3734920418/jobs/6337547681) due to changes in the lastest version of numpy which was just releases (1.24).

This PR addresses the issue in two ways:
 1. Updates code to take into account changes in the underlying libraries, and
 2. Removes the global warnings filter in favor of fine-grained warnings filtering.

The second bullet involves adding explicit checks for warnings raised by `deepcell-toolbox` itself, to ensure that warnings are being raised correctly in the expected cases.