### PR TITLE
MAINT: bump skimage lower bound.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(name=about['__title__'],
           'networkx>=2.1',
           'numpy>=1.16.6',
           'scipy>=1.3.0',
-          'scikit-image>=0.15.0',
+          'scikit-image>=0.19',
           'scikit-learn',
           'tqdm'],
       extras_require={


### PR DESCRIPTION
skimage-0.19 introduced the deprecations for the selem keyword args. This will fix issues like gh-134.

Marking as draft as there will likely be cross-talk with `deepcell-tf` and `deepcell-tracking`.